### PR TITLE
chore: add error case messages mentioned by @tomaka

### DIFF
--- a/compact/codec.ts
+++ b/compact/codec.ts
@@ -45,7 +45,7 @@ export const compact = new Codec<number | bigint>(
   },
   (cursor) => {
     const b = u8._d(cursor);
-    switch ((b & 3) as 0 | 1 | 2 | 3) {
+    switch (b & 3) {
       case 0: {
         return b >> 2;
       }
@@ -77,6 +77,9 @@ export const compact = new Codec<number | bigint>(
           base += 8n;
         }
         return decodedU32AsBigint;
+      }
+      default: {
+        throw new Error(`Encountered invalid compact mode \`${b}\``);
       }
     }
   },

--- a/compact/codec.ts
+++ b/compact/codec.ts
@@ -45,7 +45,7 @@ export const compact = new Codec<number | bigint>(
   },
   (cursor) => {
     const b = u8._d(cursor);
-    switch (b & 3) {
+    switch ((b & 3) as 0 | 1 | 2 | 3) {
       case 0: {
         return b >> 2;
       }
@@ -77,9 +77,6 @@ export const compact = new Codec<number | bigint>(
           base += 8n;
         }
         return decodedU32AsBigint;
-      }
-      default: {
-        throw new Error(`Encountered invalid compact mode \`${b}\``);
       }
     }
   },

--- a/option/codec.ts
+++ b/option/codec.ts
@@ -15,12 +15,15 @@ export class Option<Some> extends Codec<Some | undefined> {
         }
       },
       (cursor) => {
-        switch (u8._d(cursor) as 0 | 1) {
+        switch (u8._d(cursor)) {
           case 0: {
             return undefined;
           }
           case 1: {
             return someCodec._d(cursor);
+          }
+          default: {
+            throw new Error("Could not decode Option as `Some(_)` nor `None`");
           }
         }
       },

--- a/str/codec.ts
+++ b/str/codec.ts
@@ -15,6 +15,9 @@ export const str = new Codec<string>(
   (cursor) => {
     // TODO: do we like this conversion? Safeguard.
     const len = Number(compact._d(cursor));
+    if (cursor.u8a.length < cursor.i + len) {
+      throw new Error("Attempting to `str`-decode beyond bounds of input bytes");
+    }
     const slice = cursor.u8a.slice(cursor.i, cursor.i + len);
     cursor.i += len;
     return new TextDecoder().decode(slice);

--- a/union/codec.ts
+++ b/union/codec.ts
@@ -20,7 +20,11 @@ export class Union<Members extends any[]> extends Codec<Members[number]> {
       },
       (cursor) => {
         const discriminant = u8._d(cursor);
-        return memberCodecs[discriminant]!._d(cursor);
+        const memberCodec = memberCodecs[discriminant];
+        if (!memberCodec) {
+          throw new Error(`No such member codec matching the discriminant \`${discriminant}\``);
+        }
+        return memberCodec._d(cursor);
       },
     );
   }


### PR DESCRIPTION
Somewhat addresses #2  

- invalid option variant indication
- attempting to decode string larger than remaining input bytes
- add error messaging regarding not finding a member codec matching a decoded discriminant