### PR TITLE
chore: package renames

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,8 @@
-# `parity-scale-codec-ts`
+# SCALE Codecs for JavaScript and TypeScript
 
 A TypeScript implementation of [SCALE (Simple Concatenated Aggregate Little-Endian) transcoding](https://docs.substrate.io/v3/advanced/scale-codec/) (see [Rust implementation here](https://github.com/paritytech/parity-scale-codec)), which emphasizes JS-land representations and e2e type-safety. These types are described [below](#types).
 
-⚠️ `parity-scale-scale-ts` is in beta. If you encounter a bug or want to give feedback on the API design, please create an issue.
+⚠️ This TypeScript implementation of Parity's SCALE Codecs is in beta. If you encounter a bug or want to give feedback on the API design, please create an issue.
 
 ## Setup
 
@@ -23,7 +23,7 @@ npm install parity-scale-codec
 Then import as follows.
 
 ```ts
-import * as s from "parity-scale-codec-ts";
+import * as s from "parity-scale-codec";
 ```
 
 ## Usage

--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,8 @@
-# `scale-ts`
+# `parity-scale-codec-ts`
 
 A TypeScript implementation of [SCALE (Simple Concatenated Aggregate Little-Endian) transcoding](https://docs.substrate.io/v3/advanced/scale-codec/) (see [Rust implementation here](https://github.com/paritytech/parity-scale-codec)), which emphasizes JS-land representations and e2e type-safety. These types are described [below](#types).
 
-⚠️ `scale-ts` is in beta. If you encounter a bug or want to give feedback on the API design, please create an issue.
+⚠️ `parity-scale-scale-ts` is in beta. If you encounter a bug or want to give feedback on the API design, please create an issue.
 
 ## Setup
 
@@ -15,7 +15,7 @@ import * as s from "https://deno.land/x/scale/mod.ts";
 If you're using [Node](https://nodejs.org/), install as follows.
 
 ```
-npm install scale-combinators
+npm install parity-scale-codec
 ```
 
 > NOTE: The published package name is (while in beta) subject to change
@@ -23,7 +23,7 @@ npm install scale-combinators
 Then import as follows.
 
 ```ts
-import * as s from "scale-combinators";
+import * as s from "parity-scale-codec-ts";
 ```
 
 ## Usage

--- a/_tasks/build_npm_pkg.ts
+++ b/_tasks/build_npm_pkg.ts
@@ -10,7 +10,7 @@ await build({
   outDir: "target/npm_pkg",
   package: {
     // TODO: rename if/when we get access to `scale` package name
-    name: "scale-combinators",
+    name: "parity-scale-codec",
     version: Deno.args[0]!,
     description: DESCRIPTION,
   },

--- a/_tasks/build_npm_pkg.ts
+++ b/_tasks/build_npm_pkg.ts
@@ -3,7 +3,7 @@ import { build } from "x/dnt/mod.ts";
 
 await emptyDir("target/npm_pkg");
 
-const DESCRIPTION = "SCALE Transcoding in TypeScript";
+const DESCRIPTION = "A TypeScript Reference Implementation of SCALE Transcoding";
 
 await build({
   entryPoints: ["mod.ts"],
@@ -13,6 +13,8 @@ await build({
     name: "parity-scale-codec",
     version: Deno.args[0]!,
     description: DESCRIPTION,
+    sideEffects: false,
+    repository: "github:paritytech/parity-scale-codec-ts",
   },
   shims: {},
   compilerOptions: {

--- a/words.txt
+++ b/words.txt
@@ -1,4 +1,5 @@
 bindgen
+paritytech
 lipsum
 cummon
 bitvec


### PR DESCRIPTION
- The repo itself has been renamed to `parity-scale-codec-ts`
- The package will be published to NPM and Denoland/x under the name `parity-scale-codec`