### PR TITLE
feat: key literal unions / native TS enums

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -230,6 +230,28 @@ const bytes2 = codec.encode({
 const value2 = codec.decode(bytes2);
 ```
 
+#### Key Literals (aka., Native JS Enums)
+
+```ts
+enum Dinosaur {
+  Liopleurodon = "Liopleurodon",
+  Kosmoceratops = "Kosmoceratops",
+  Psittacosaurus = "Psittacosaurus",
+}
+
+const codec = s.keyLiteralUnion(
+  Dinosaur.Liopleurodon,
+  Dinosaur.Kosmoceratops,
+  Dinosaur.Psittacosaurus,
+);
+
+const encoded = codec.encode(Dinosaur.Psittacosaurus);
+assertEquals(encoded, new Uint8Array([2]));
+
+const decoded = codec.decode(encoded);
+assertEquals(decoded, Dinosaur.Psittacosaurus);
+```
+
 <!-- TODO: narrowing gif -->
 
 ### Instance

--- a/Readme.md
+++ b/Readme.md
@@ -230,7 +230,7 @@ const bytes2 = codec.encode({
 const value2 = codec.decode(bytes2);
 ```
 
-#### Key Literals (aka., Native JS Enums)
+#### Key Literals (aka., Native TypeScript Enums)
 
 ```ts
 enum Dinosaur {

--- a/mod.ts
+++ b/mod.ts
@@ -13,4 +13,5 @@ export * from "./tuple/codec.ts";
 export * from "./union/codec.ts";
 export * from "./union/comparable_value/codec.ts";
 export * from "./union/implicit_init_num_enum/codec.ts";
+export * from "./union/key/codec.ts";
 export * from "./union/tagged/codec.ts";

--- a/union/key/codec.ts
+++ b/union/key/codec.ts
@@ -1,0 +1,29 @@
+import { Codec } from "../../common.ts";
+import { u8 } from "../../int/codec.ts";
+
+export class KeyLiteralUnion<Member extends PropertyKey> extends Codec<Member> {
+  constructor(...members: Member[]) {
+    const discriminantByKey = members.reduce<Partial<Record<Member, number>>>((acc, cur, i) => {
+      return {
+        ...acc,
+        [cur]: i,
+      };
+    }, {}) as Partial<Record<Member, number>>;
+    super(
+      () => {
+        return u8._s(undefined as any);
+      },
+      (cursor, value) => {
+        const discriminant = discriminantByKey[value]!;
+        u8._e(cursor, discriminant);
+      },
+      (cursor) => {
+        const discriminant = u8._d(cursor);
+        return members[discriminant]!;
+      },
+    );
+  }
+}
+export const keyLiteralUnion = <Member extends PropertyKey>(...members: Member[]): KeyLiteralUnion<Member> => {
+  return new KeyLiteralUnion(...members);
+};

--- a/union/key/test.ts
+++ b/union/key/test.ts
@@ -1,0 +1,31 @@
+import * as asserts from "std/testing/asserts.ts";
+import { keyLiteralUnion } from "../../mod.ts";
+
+enum Name {
+  Ross = "Ross",
+  Alisa = "Alisa",
+  Stefan = "Stefan",
+  Raoul = "Raoul",
+  James = "James",
+  David = "David",
+  Pierre = "Pierre",
+}
+
+const ordered = [
+  Name.Ross,
+  Name.Alisa,
+  Name.Stefan,
+  Name.Raoul,
+  Name.James,
+  Name.David,
+  Name.Pierre,
+];
+
+Deno.test("Key Literal Unions", () => {
+  const c = keyLiteralUnion(...ordered);
+  ordered.forEach((name) => {
+    const encoded = c.encode(name);
+    const decoded = c.decode(encoded);
+    asserts.assertEquals(name, decoded);
+  });
+});

--- a/words.txt
+++ b/words.txt
@@ -14,3 +14,6 @@ typeof
 denoland
 contravariance
 rustup
+Liopleurodon
+Kosmoceratops
+Psittacosaurus


### PR DESCRIPTION
This PR implements a codec which can encode from / decode to a TS enum of any kind.

```ts
enum Dinosaur {
  Liopleurodon = "Liopleurodon",
  Kosmoceratops = "Kosmoceratops",
  Psittacosaurus = "Psittacosaurus",
}

const codec = s.keyLiteralUnion(
  Dinosaur.Liopleurodon,
  Dinosaur.Kosmoceratops,
  Dinosaur.Psittacosaurus,
);

const encoded = codec.encode(Dinosaur.Psittacosaurus);
assertEquals(encoded, new Uint8Array([2]));

const decoded = codec.decode(encoded);
assertEquals(decoded, Dinosaur.Psittacosaurus);
```