### PR TITLE
Improve type safety of instance

### DIFF
--- a/instance/codec.ts
+++ b/instance/codec.ts
@@ -1,5 +1,5 @@
-import { Codec, Entries } from "../common.ts";
-import { record } from "../record/codec.ts";
+import { Codec, Entries, Native } from "../common.ts";
+import { Field, NativeRecord, record } from "../record/codec.ts";
 
 export class Instance<Ctor extends new(...args: any[]) => any> extends Codec<InstanceType<Ctor>> {
   constructor(
@@ -30,9 +30,18 @@ export class Instance<Ctor extends new(...args: any[]) => any> extends Codec<Ins
  * @param fields the ordered fields used to decode params for the constructor / encode from the instance
  * @returns the instance codec
  */
-export const instance = <Ctor extends new(...args: any[]) => any>(
+export const instance = <
+  Ctor extends new(
+    ...args: {
+      [K in keyof Fields]: Native<Extract<Fields[K], Field>[1]>;
+    }
+  ) => NativeRecord<Fields>,
+  Fields extends Field<EntryKey, EntryValueCodec>[],
+  EntryKey extends PropertyKey,
+  EntryValueCodec extends Codec,
+>(
   ctor: Ctor,
-  ...fields: Entries<InstanceType<Ctor>>
+  ...fields: Fields
 ) => {
-  return new Instance(ctor, ...fields);
+  return new Instance(ctor, ...(fields as any));
 };

--- a/instance/test.ts
+++ b/instance/test.ts
@@ -1,20 +1,21 @@
 import * as asserts from "std/testing/asserts.ts";
 import * as s from "../mod.ts";
 
-Deno.test("Instances", () => {
-  class MyError extends Error {
-    constructor(
-      readonly code: number,
-      readonly message: string,
-      readonly payload: {
-        a: string;
-        b: number;
-        c: boolean;
-      },
-    ) {
-      super();
-    }
+class MyError extends Error {
+  constructor(
+    readonly code: number,
+    readonly message: string,
+    readonly payload: {
+      a: string;
+      b: number;
+      c: boolean;
+    },
+  ) {
+    super();
   }
+}
+
+Deno.test("Instances", () => {
   const c = s.instance(
     MyError,
     ["code", s.u8],
@@ -43,3 +44,29 @@ Deno.test("Instances", () => {
   asserts.assertEquals(myErr.message, myErrDecoded.message);
   asserts.assertEquals(myErr.payload, myErrDecoded.payload);
 });
+
+namespace _typeTests {
+  // @ts-ignore: Prevent execution
+  if (1 as 0) return;
+
+  let sPayload = s.record(
+    ["a", s.str],
+    ["b", s.u8],
+    ["c", s.bool],
+  );
+
+  // ok
+  s.instance(MyError, ["code", s.u8], ["message", s.str], ["payload", sPayload]);
+
+  // @ts-expect-error: Missing constructor parameters
+  s.instance(MyError);
+
+  // @ts-expect-error: Constructor parameter type mismatch
+  s.instance(MyError, ["code", s.u8], ["message", s.str], ["name", s.str]);
+
+  // @ts-expect-error: Missing field
+  s.instance(MyError, ["code", s.u8], ["message", s.str], ["paidload", sPayload]);
+
+  // @ts-expect-error: Field type mismatch
+  s.instance(MyError, ["code", s.u8], ["message", s.str], ["name", sPayload]);
+}


### PR DESCRIPTION
In addition to requiring that the entries align with properties of the class (which it did before), this additionally requires that the entries align with the types of the constructor parameters.