### PR TITLE
Add some benchmarks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,29 @@
+name: Bench
+on: push
+jobs:
+  test:
+    name: Run Benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          target: wasm32-unknown-unknown
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - run: cargo install wasm-bindgen-cli || true
+      - run: deno task build_fixtures
+      - run: deno task bench

--- a/array/bench.ts
+++ b/array/bench.ts
@@ -1,0 +1,18 @@
+import * as s from "../mod.ts";
+import { benchCodec } from "../test-util.ts";
+
+function arr<T>(length: number, el: (i: number) => T): T[] {
+  return Array.from({ length }, (_, i) => el(i));
+}
+
+benchCodec("bool[0]", s.array(s.bool), []);
+benchCodec("u128[0]", s.array(s.u128), []);
+benchCodec("compact[0]", s.array(s.compact), []);
+
+benchCodec("bool[128]", s.array(s.bool), arr(128, (i) => i % 2 === 0));
+benchCodec("u128[128]", s.array(s.u128), arr(128, (i) => 2n ** BigInt(i % 100) + BigInt(i)));
+benchCodec("compact[128]", s.array(s.compact), arr(128, (i) => 2n ** BigInt(i % 100) + BigInt(i)));
+
+benchCodec("bool[16384]", s.array(s.bool), arr(16384, (i) => i % 2 === 0));
+benchCodec("u128[16384]", s.array(s.u128), arr(16384, (i) => 2n ** BigInt(i % 100) + BigInt(i)));
+benchCodec("compact[16384]", s.array(s.compact), arr(16384, (i) => 2n ** BigInt(i % 100) + BigInt(i)));

--- a/bool/bench.ts
+++ b/bool/bench.ts
@@ -1,0 +1,4 @@
+import { benchCodec } from "../test-util.ts";
+import * as s from "./codec.ts";
+
+benchCodec("bool", s.bool, true);

--- a/compact/bench.ts
+++ b/compact/bench.ts
@@ -1,0 +1,8 @@
+import { benchCodec } from "../test-util.ts";
+import * as s from "./codec.ts";
+
+benchCodec("compact (u8)", s.compact, 2 ** (8 - 2) - 1);
+benchCodec("compact (u16)", s.compact, 2 ** (16 - 2) - 1);
+benchCodec("compact (u32)", s.compact, 2 ** (32 - 2) - 1);
+benchCodec("compact (b64)", s.compact, 2n ** 64n - 1n);
+benchCodec("compact (b128)", s.compact, 2n ** 128n - 1n);

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -29,6 +29,7 @@
     "build_wasm_bindings": "wasm-bindgen target/wasm32-unknown-unknown/release/scale_fixtures.wasm --target deno --weak-refs --out-dir target/fixtures",
     "build_fixtures": "deno task build_wasm && deno task build_wasm_bindings",
     "build_npm_pkg": "deno run -A --no-check=remote _tasks/build_npm_pkg.ts",
-    "test": "deno test -A --no-check=remote -L=info"
+    "test": "deno test -A --no-check=remote -L=info",
+    "bench": "deno bench -A --no-check=remote --unstable"
   }
 }

--- a/dummy/bench.ts
+++ b/dummy/bench.ts
@@ -1,0 +1,5 @@
+import * as s from "../mod.ts";
+import { benchCodec } from "../test-util.ts";
+
+// Useful for testing overhead of Codec
+benchCodec("dummy", s.dummy(null), null);

--- a/int/bench.ts
+++ b/int/bench.ts
@@ -1,0 +1,14 @@
+import { benchCodec } from "../test-util.ts";
+import * as s from "./codec.ts";
+
+benchCodec("u8", s.u8, 123);
+benchCodec("u16", s.u16, 123);
+benchCodec("u32", s.u32, 123);
+benchCodec("u64", s.u64, 123n);
+benchCodec("u128", s.u128, 123n);
+
+benchCodec("i8", s.i8, 123);
+benchCodec("i16", s.i16, 123);
+benchCodec("i32", s.i32, 123);
+benchCodec("i64", s.i64, 123n);
+benchCodec("i128", s.i128, 123n);

--- a/option/bench.ts
+++ b/option/bench.ts
@@ -1,0 +1,8 @@
+import * as s from "../mod.ts";
+import { benchCodec } from "../test-util.ts";
+
+benchCodec("None<bool>", s.option(s.bool), undefined);
+benchCodec("None<u128>", s.option(s.u128), undefined);
+
+benchCodec("Some<bool>", s.option(s.bool), true);
+benchCodec("Some<u128>", s.option(s.u128), 12345678901234567890n);

--- a/record/bench.ts
+++ b/record/bench.ts
@@ -1,0 +1,24 @@
+import * as s from "../mod.ts";
+import { benchCodec } from "../test-util.ts";
+
+// for comparison
+benchCodec("u128", s.u128, 123n);
+
+benchCodec("{}", s.record(), {});
+benchCodec("{ x: u128 }", s.record(["x", s.u128]), { x: 123n });
+benchCodec(
+  "{ x: u128, y: u128 }",
+  s.record(["x", s.u128], ["y", s.u128]),
+  { x: 123n, y: 456n },
+);
+benchCodec(
+  "{ x: u128, y: u128, z: u128 }",
+  s.record(["x", s.u128], ["y", s.u128], ["z", s.u128]),
+  { x: 123n, y: 456n, z: 789n },
+);
+
+const longKey =
+  "thisIsTheKeyThatNeverEnds_itJustGoesRoundAndRoundMyFriends_somePeopleStartedWritingIt_notKnowingWhatItWas_andWeContinueWritingItForeverJustBecause_"
+    .repeat(1000);
+
+benchCodec("{ [longKey]: u128 }", s.record([longKey, s.u128]), { [longKey]: 123n });

--- a/str/bench.ts
+++ b/str/bench.ts
@@ -1,0 +1,20 @@
+import { dirname, join } from "std/path/mod.ts";
+import * as s from "../mod.ts";
+import { benchCodec } from "../test-util.ts";
+
+const trolleybus = "🚎";
+const special = "œ∑é®†¥üîøπåß∂ƒ©˙∆˚¬Ω≈ç√∫ñµ";
+const lipsum = await fetch(join(dirname(import.meta.url), "../lipsum.txt")).then((x) => x.text());
+const cargoLock = await fetch(join(dirname(import.meta.url), "../Cargo.lock")).then((x) => x.text());
+
+benchCodec(`""`, s.str, "");
+benchCodec(`"abc"`, s.str, "abc");
+benchCodec(`trolleybus`, s.str, trolleybus);
+benchCodec(`special`, s.str, special);
+benchCodec(`lipsum`, s.str, lipsum);
+benchCodec(`cargoLock`, s.str, cargoLock);
+benchCodec(`"abc" * 1000`, s.str, "abc".repeat(1000));
+benchCodec(`trolleybus * 1000`, s.str, trolleybus.repeat(1000));
+benchCodec(`special * 1000`, s.str, special.repeat(1000));
+benchCodec(`lipsum * 1000`, s.str, lipsum.repeat(1000));
+benchCodec(`cargoLock * 1000`, s.str, cargoLock.repeat(1000));

--- a/test-util.ts
+++ b/test-util.ts
@@ -1,3 +1,4 @@
+import { Codec } from "./common.ts";
 export * as fixtures from "./target/fixtures/scale_fixtures.js";
 
 export const visitFixtures = <D, N>(
@@ -19,3 +20,13 @@ export const visitFixtures = <D, N>(
 export const constrainedIdentity = <T>() => {
   return (t: T) => t;
 };
+
+export function benchCodec<T>(name: string, codec: Codec<T>, value: T) {
+  Deno.bench(`- ${name} [encode]`, () => {
+    codec.encode(value);
+  });
+  const encoded = codec.encode(value);
+  Deno.bench(`  ${name} [decode]`, () => {
+    codec.decode(encoded);
+  });
+}

--- a/test-util.ts
+++ b/test-util.ts
@@ -1,3 +1,5 @@
+/// <reference lib="deno.unstable"/>
+
 import { Codec } from "./common.ts";
 export * as fixtures from "./target/fixtures/scale_fixtures.js";
 

--- a/test-util.ts
+++ b/test-util.ts
@@ -22,11 +22,11 @@ export const constrainedIdentity = <T>() => {
 };
 
 export function benchCodec<T>(name: string, codec: Codec<T>, value: T) {
-  Deno.bench(`- ${name} [encode]`, () => {
+  const encoded = codec.encode(value);
+  Deno.bench(`- ${name} (${encoded.length}B) [encode] `, () => {
     codec.encode(value);
   });
-  const encoded = codec.encode(value);
-  Deno.bench(`  ${name} [decode]`, () => {
+  Deno.bench(`  ${name} (${encoded.length}B) [decode]`, () => {
     codec.decode(encoded);
   });
 }

--- a/tuple/bench.ts
+++ b/tuple/bench.ts
@@ -1,0 +1,10 @@
+import * as s from "../mod.ts";
+import { benchCodec } from "../test-util.ts";
+
+// for comparison
+benchCodec("u128", s.u128, 123n);
+
+benchCodec("[]", s.tuple(), []);
+benchCodec("[u128]", s.tuple(s.u128), [123n]);
+benchCodec("[u128, u128]", s.tuple(s.u128, s.u128), [123n, 456n]);
+benchCodec("[u128, u128, u128]", s.tuple(s.u128, s.u128, s.u128), [123n, 456n, 789n]);


### PR DESCRIPTION
This adds a bunch of benchmarks, and covers most codecs. There are a few codecs remaining without benchmarks (I think just result and union), but those can be added later.

Running `deno task bench` will run the full benchmark (around one minute on my machine), and `deno task bench [codec]` will run benchmarks just for that codec.

This also adds a workflow to automatically run benchmarks on CI, and the results are viewable in the output. I was originally going to have a comment be added to the commit with the benchmark results (like [this](https://github.com/paritytech/parity-scale-codec-ts/commit/15e9577eb3691a834e8bd5b867a36da5050de4f5#commitcomment-73445288), though the formatting is messed up), but the comment would give a notification for each commit, which I thought was too annoying.
