### PR TITLE
New naming conventions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,7 +37,7 @@ import * as $ from "parity-scale-codec";
 ```ts
 import * as $ from "https://deno.land/x/scale/mod.ts";
 
-const codec = $.record(
+const $person = $.record(
   ["name", $.str],
   ["nickName", $.str],
   ["superPower", $.option($.str)],
@@ -49,8 +49,8 @@ const valueToEncode = {
   superPower: "Hydrokinesis",
 };
 
-const encodedBytes = codec.encode(valueToEncode);
-const decodedValue = codec.decode(encodedBytes);
+const encodedBytes = $person.encode(valueToEncode);
+const decodedValue = $person.decode(encodedBytes);
 
 assertEquals(decodedValue, valueToEncode);
 ```
@@ -58,7 +58,7 @@ assertEquals(decodedValue, valueToEncode);
 To extract the JS-native TypeScript type from a given codec, use the `Native` utility type.
 
 ```ts
-type NativeType = $.Native<typeof codec>;
+type NativeType = $.Native<typeof $person>;
 
 assertTypeEquals<NativeType, {
   name: string;
@@ -76,7 +76,7 @@ interface Person {
   superPower: string | undefined;
 }
 
-const codec: Codec<Person> = $.record(
+const $person: Codec<Person> = $.record(
   ["name", $.str],
   ["nickName", $.str],
   ["superPower", $.option($.str)],
@@ -86,7 +86,7 @@ const codec: Codec<Person> = $.record(
 This has the added benefit of producing type errors if the codec does not directly mirror the TS type.
 
 ```ts
-const codec: Codec<NativeType> = $.record(
+const $person: Codec<Person> = $.record(
   //  ~~~~~
   //  ^ error (message below)
   ["nickName", $.str],
@@ -127,13 +127,13 @@ Other such integer types include `i8`, `u16`, `i16`, `u32`, `i32`, `u64`, `i64`,
 ### Options
 
 ```ts
-const codec = $.option($.u8);
+const $foo = $.option($.u8);
 
-const bytes1 = codec.encode(27);
-const value1 = codec.decode(bytes1);
+const bytes1 = $foo.encode(27);
+const value1 = $foo.decode(bytes1);
 
-const bytes2 = codec.encode(undefined);
-const value2 = codec.decode(bytes2);
+const bytes2 = $foo.encode(undefined);
+const value2 = $foo.decode(bytes2);
 ```
 
 ### Arrays
@@ -141,45 +141,45 @@ const value2 = codec.decode(bytes2);
 #### Sized
 
 ```ts
-const codec = $.sizedArray($.u8, 2);
+const $bar = $.sizedArray($.u8, 2);
 
-const bytes = codec.encode([3, 9]);
-const value = codec.decode(bytes);
+const bytes = $bar.encode([3, 9]);
+const value = $bar.decode(bytes);
 ```
 
 #### Dynamic
 
 ```ts
-const codec = $.array($.u8);
+const $baz = $.array($.u8);
 
-const bytes = codec.encode([1, 2, 3, 4, 5]);
-const value = codec.decode(bytes);
+const bytes = $baz.encode([1, 2, 3, 4, 5]);
+const value = $baz.decode(bytes);
 ```
 
 ### Tuples
 
 ```ts
-const codec = $.tuple($.bool, $.u8, $.str);
+const $qux = $.tuple($.bool, $.u8, $.str);
 
-const bytes = codec.encode([true, 81, "｡＾・ｪ・＾｡"]);
-const value = codec.decode(bytes);
+const bytes = $qux.encode([true, 81, "｡＾・ｪ・＾｡"]);
+const value = $qux.decode(bytes);
 ```
 
 ### Records
 
 ```ts
-const codec = $.record(
+const $person = $.record(
   ["name", $.str],
   ["nickName", $.str],
   ["superPower", $.option($.str)],
 );
 
-const bytes = codec.encode({
+const bytes = $person.encode({
   name: "Magdalena",
   nickName: "Magz",
   superPower: "Hydrokinesis",
 });
-const value = codec.decode(bytes);
+const value = $person.decode(bytes);
 ```
 
 ### Unions
@@ -187,7 +187,7 @@ const value = codec.decode(bytes);
 #### Explicitly Discriminated
 
 ```ts
-const codec = $.union(
+const $strOrNum = $.union(
   (value) => { // Discriminate
     if (typeof value === "string") {
       return 0;
@@ -201,33 +201,33 @@ const codec = $.union(
   $.u8, // Member `1`
 );
 
-const bytes1 = codec.encode(27);
-const value1 = codec.decode(bytes1);
+const bytes1 = $strOrNum.encode(27);
+const value1 = $strOrNum.decode(bytes1);
 
-const bytes2 = codec.encode("Parity");
-const value2 = codec.decode(bytes2);
+const bytes2 = $strOrNum.encode("Parity");
+const value2 = $strOrNum.decode(bytes2);
 ```
 
 #### Tagged
 
 ```ts
-const codec = $.taggedUnion(
+const $pet = $.taggedUnion(
   "_tag",
   ["dog", ["bark", $.str]],
-  ["cat", ["pur", $.str]],
+  ["cat", ["purr", $.str]],
 );
 
-const bytes1 = codec.encode({
+const bytes1 = $pet.encode({
   _tag: "dog",
   bark: "Roof",
 });
-const value1 = codec.decode(bytes1);
+const value1 = $pet.decode(bytes1);
 
-const bytes2 = codec.encode({
+const bytes2 = $pet.encode({
   _tag: "cat",
-  pur: "Meow",
+  purr: "Meow",
 });
-const value2 = codec.decode(bytes2);
+const value2 = $pet.decode(bytes2);
 ```
 
 #### Key Literals (aka., Native TypeScript Enums)
@@ -239,16 +239,16 @@ enum Dinosaur {
   Psittacosaurus = "Psittacosaurus",
 }
 
-const codec = $.keyLiteralUnion(
+const $dinosaur = $.keyLiteralUnion(
   Dinosaur.Liopleurodon,
   Dinosaur.Kosmoceratops,
   Dinosaur.Psittacosaurus,
 );
 
-const encoded = codec.encode(Dinosaur.Psittacosaurus);
+const encoded = $dinosaur.encode(Dinosaur.Psittacosaurus);
 assertEquals(encoded, new Uint8Array([2]));
 
-const decoded = codec.decode(encoded);
+const decoded = $dinosaur.decode(encoded);
 assertEquals(decoded, Dinosaur.Psittacosaurus);
 ```
 
@@ -279,7 +279,7 @@ class MyError extends Error {
 We can do so as follows.
 
 ```ts
-const codec = $.instance(
+const $myError = $.instance(
   MyError,
   ["code", $.u8],
   ["message", $.str],
@@ -307,8 +307,8 @@ const myError = new MyError(
   },
 );
 
-const encodedBytes = codec.encode(myError);
-const decoded = codec.decode(encodedBytes);
+const encodedBytes = $myError.encode(myError);
+const decoded = $myError.decode(encodedBytes);
 ```
 
 > Note: executing an equality assertion between `myError` and `decoded` will fail, as they contain different stack traces.
@@ -321,13 +321,13 @@ const decoded = codec.decode(encodedBytes);
 class MyError {
   constructor(readonly message: string) {}
 }
-const errorCodec = $.instance(MyError, ["message", $.str]);
+const $myError = $.instance(MyError, ["message", $.str]);
 
-const resultCodec = $.Result(errorCodec, $.str);
+const $myResult = $.result($myError, $.str);
 
-const errorBytes = resultCodec.encode(new MyError("Uh oh!"));
-const errorDecoded = resultCodec.decode(errorBytes);
+const errorBytes = $myResult.encode(new MyError("Uh oh!"));
+const errorDecoded = $myResult.decode(errorBytes);
 
-const okBytes = resultCodec.encode("YES!");
-const okDecoded = resultCodec.decode(okBytes);
+const okBytes = $myResult.encode("YES!");
+const okDecoded = $myResult.decode(okBytes);
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -9,7 +9,7 @@ A TypeScript implementation of [SCALE (Simple Concatenated Aggregate Little-Endi
 If you're using [Deno](https://deno.land/), simply import via the `denoland/x` specifier.
 
 ```ts
-import * as s from "https://deno.land/x/scale/mod.ts";
+import * as $ from "https://deno.land/x/scale/mod.ts";
 ```
 
 If you're using [Node](https://nodejs.org/), install as follows.
@@ -23,7 +23,7 @@ npm install parity-scale-codec
 Then import as follows.
 
 ```ts
-import * as s from "parity-scale-codec";
+import * as $ from "parity-scale-codec";
 ```
 
 ## Usage
@@ -35,12 +35,12 @@ import * as s from "parity-scale-codec";
 ## Example
 
 ```ts
-import * as s from "https://deno.land/x/scale/mod.ts";
+import * as $ from "https://deno.land/x/scale/mod.ts";
 
-const codec = s.record(
-  ["name", s.str],
-  ["nickName", s.str],
-  ["superPower", s.option(s.str)],
+const codec = $.record(
+  ["name", $.str],
+  ["nickName", $.str],
+  ["superPower", $.option($.str)],
 );
 
 const valueToEncode = {
@@ -58,7 +58,7 @@ assertEquals(decodedValue, valueToEncode);
 To extract the JS-native TypeScript type from a given codec, use the `Native` utility type.
 
 ```ts
-type NativeType = s.Native<typeof codec>;
+type NativeType = $.Native<typeof codec>;
 
 assertTypeEquals<NativeType, {
   name: string;
@@ -76,21 +76,21 @@ interface Person {
   superPower: string | undefined;
 }
 
-const codec: Codec<Person> = s.record(
-  ["name", s.str],
-  ["nickName", s.str],
-  ["superPower", s.option(s.str)],
+const codec: Codec<Person> = $.record(
+  ["name", $.str],
+  ["nickName", $.str],
+  ["superPower", $.option($.str)],
 );
 ```
 
 This has the added benefit of producing type errors if the codec does not directly mirror the TS type.
 
 ```ts
-const codec: Codec<NativeType> = s.record(
+const codec: Codec<NativeType> = $.record(
   //  ~~~~~
   //  ^ error (message below)
-  ["nickName", s.str],
-  ["superPower", s.option(s.str)],
+  ["nickName", $.str],
+  ["superPower", $.option($.str)],
 );
 ```
 
@@ -111,15 +111,15 @@ This library **intentionally** does not check for conditions that would suggest 
 ### Booleans
 
 ```ts
-const bytes = s.bool.encode(true);
-const value = s.bool.decode(bytes);
+const bytes = $.bool.encode(true);
+const value = $.bool.decode(bytes);
 ```
 
 ### Integers
 
 ```ts
-const bytes = s.u8.encode(9);
-const value = s.u8.decode(bytes);
+const bytes = $.u8.encode(9);
+const value = $.u8.decode(bytes);
 ```
 
 Other such integer types include `i8`, `u16`, `i16`, `u32`, `i32`, `u64`, `i64`, `u128`, `i128` and [`compact`](https://docs.substrate.io/v3/advanced/scale-codec/#compactgeneral-integers).
@@ -127,7 +127,7 @@ Other such integer types include `i8`, `u16`, `i16`, `u32`, `i32`, `u64`, `i64`,
 ### Options
 
 ```ts
-const codec = s.option(s.u8);
+const codec = $.option($.u8);
 
 const bytes1 = codec.encode(27);
 const value1 = codec.decode(bytes1);
@@ -141,7 +141,7 @@ const value2 = codec.decode(bytes2);
 #### Sized
 
 ```ts
-const codec = s.sizedArray(s.u8, 2);
+const codec = $.sizedArray($.u8, 2);
 
 const bytes = codec.encode([3, 9]);
 const value = codec.decode(bytes);
@@ -150,7 +150,7 @@ const value = codec.decode(bytes);
 #### Dynamic
 
 ```ts
-const codec = s.array(s.u8);
+const codec = $.array($.u8);
 
 const bytes = codec.encode([1, 2, 3, 4, 5]);
 const value = codec.decode(bytes);
@@ -159,7 +159,7 @@ const value = codec.decode(bytes);
 ### Tuples
 
 ```ts
-const codec = s.tuple(s.bool, s.u8, s.str);
+const codec = $.tuple($.bool, $.u8, $.str);
 
 const bytes = codec.encode([true, 81, "｡＾・ｪ・＾｡"]);
 const value = codec.decode(bytes);
@@ -168,10 +168,10 @@ const value = codec.decode(bytes);
 ### Records
 
 ```ts
-const codec = s.record(
-  ["name", s.str],
-  ["nickName", s.str],
-  ["superPower", s.option(s.str)],
+const codec = $.record(
+  ["name", $.str],
+  ["nickName", $.str],
+  ["superPower", $.option($.str)],
 );
 
 const bytes = codec.encode({
@@ -187,7 +187,7 @@ const value = codec.decode(bytes);
 #### Explicitly Discriminated
 
 ```ts
-const codec = s.union(
+const codec = $.union(
   (value) => { // Discriminate
     if (typeof value === "string") {
       return 0;
@@ -197,8 +197,8 @@ const codec = s.union(
       throw new Error("Unreachable");
     }
   },
-  s.str, // Member `0`
-  s.u8, // Member `1`
+  $.str, // Member `0`
+  $.u8, // Member `1`
 );
 
 const bytes1 = codec.encode(27);
@@ -211,10 +211,10 @@ const value2 = codec.decode(bytes2);
 #### Tagged
 
 ```ts
-const codec = s.taggedUnion(
+const codec = $.taggedUnion(
   "_tag",
-  ["dog", ["bark", s.str]],
-  ["cat", ["pur", s.str]],
+  ["dog", ["bark", $.str]],
+  ["cat", ["pur", $.str]],
 );
 
 const bytes1 = codec.encode({
@@ -239,7 +239,7 @@ enum Dinosaur {
   Psittacosaurus = "Psittacosaurus",
 }
 
-const codec = s.keyLiteralUnion(
+const codec = $.keyLiteralUnion(
   Dinosaur.Liopleurodon,
   Dinosaur.Kosmoceratops,
   Dinosaur.Psittacosaurus,
@@ -279,16 +279,16 @@ class MyError extends Error {
 We can do so as follows.
 
 ```ts
-const codec = s.instance(
+const codec = $.instance(
   MyError,
-  ["code", s.u8],
-  ["message", s.str],
+  ["code", $.u8],
+  ["message", $.str],
   [
     "payload",
-    s.record(
-      ["a", s.str],
-      ["b", s.u8],
-      ["c", s.bool],
+    $.record(
+      ["a", $.str],
+      ["b", $.u8],
+      ["c", $.bool],
     ),
   ],
 );
@@ -321,9 +321,9 @@ const decoded = codec.decode(encodedBytes);
 class MyError {
   constructor(readonly message: string) {}
 }
-const errorCodec = s.instance(MyError, ["message", s.str]);
+const errorCodec = $.instance(MyError, ["message", $.str]);
 
-const resultCodec = s.Result(errorCodec, s.str);
+const resultCodec = $.Result(errorCodec, $.str);
 
 const errorBytes = resultCodec.encode(new MyError("Uh oh!"));
 const errorDecoded = resultCodec.decode(errorBytes);

--- a/array/bench.ts
+++ b/array/bench.ts
@@ -1,18 +1,18 @@
-import * as s from "../mod.ts";
+import * as $ from "../mod.ts";
 import { benchCodec } from "../test-util.ts";
 
 function arr<T>(length: number, el: (i: number) => T): T[] {
   return Array.from({ length }, (_, i) => el(i));
 }
 
-benchCodec("bool[0]", s.array(s.bool), []);
-benchCodec("u128[0]", s.array(s.u128), []);
-benchCodec("compact[0]", s.array(s.compact), []);
+benchCodec("bool[0]", $.array($.bool), []);
+benchCodec("u128[0]", $.array($.u128), []);
+benchCodec("compact[0]", $.array($.compact), []);
 
-benchCodec("bool[128]", s.array(s.bool), arr(128, (i) => i % 2 === 0));
-benchCodec("u128[128]", s.array(s.u128), arr(128, (i) => 2n ** BigInt(i % 100) + BigInt(i)));
-benchCodec("compact[128]", s.array(s.compact), arr(128, (i) => 2n ** BigInt(i % 100) + BigInt(i)));
+benchCodec("bool[128]", $.array($.bool), arr(128, (i) => i % 2 === 0));
+benchCodec("u128[128]", $.array($.u128), arr(128, (i) => 2n ** BigInt(i % 100) + BigInt(i)));
+benchCodec("compact[128]", $.array($.compact), arr(128, (i) => 2n ** BigInt(i % 100) + BigInt(i)));
 
-benchCodec("bool[16384]", s.array(s.bool), arr(16384, (i) => i % 2 === 0));
-benchCodec("u128[16384]", s.array(s.u128), arr(16384, (i) => 2n ** BigInt(i % 100) + BigInt(i)));
-benchCodec("compact[16384]", s.array(s.compact), arr(16384, (i) => 2n ** BigInt(i % 100) + BigInt(i)));
+benchCodec("bool[16384]", $.array($.bool), arr(16384, (i) => i % 2 === 0));
+benchCodec("u128[16384]", $.array($.u128), arr(16384, (i) => 2n ** BigInt(i % 100) + BigInt(i)));
+benchCodec("compact[16384]", $.array($.compact), arr(16384, (i) => 2n ** BigInt(i % 100) + BigInt(i)));

--- a/array/codec.ts
+++ b/array/codec.ts
@@ -9,7 +9,7 @@ type ArrayOfLenth<
   : N extends A["length"] ? A
   : ArrayOfLenth<N, T, [...A, T]>;
 
-export class SizedArray<
+export class SizedArrayCodec<
   El,
   Len extends number,
 > extends Codec<ArrayOfLenth<Len, El>> {
@@ -31,7 +31,7 @@ export class SizedArray<
         }
       },
       (cursor) => {
-        const result: El[] = globalThis.Array(len);
+        const result: El[] = Array(len);
         for (let i = 0; i < len; i += 1) {
           result[i] = elCodec._d(cursor);
         }
@@ -46,11 +46,11 @@ export const sizedArray = <
 >(
   elCodec: Codec<El>,
   len: Len,
-): SizedArray<El, Len> => {
-  return new SizedArray(elCodec, len);
+): SizedArrayCodec<El, Len> => {
+  return new SizedArrayCodec(elCodec, len);
 };
 
-export class Array<El> extends Codec<El[]> {
+export class ArrayCodec<El> extends Codec<El[]> {
   constructor(elCodec: Codec<El>) {
     super(
       (value) => {
@@ -68,7 +68,7 @@ export class Array<El> extends Codec<El[]> {
       },
       (cursor) => {
         const len = Number(compact._d(cursor));
-        const result: El[] = globalThis.Array(len);
+        const result: El[] = Array(len);
         for (let i = 0; i < len; i += 1) {
           result[i] = elCodec._d(cursor);
         }
@@ -77,6 +77,6 @@ export class Array<El> extends Codec<El[]> {
     );
   }
 }
-export const array = <El>(elCodec: Codec<El>): Array<El> => {
-  return new Array(elCodec);
+export const array = <El>(elCodec: Codec<El>): ArrayCodec<El> => {
+  return new ArrayCodec(elCodec);
 };

--- a/array/test.ts
+++ b/array/test.ts
@@ -1,12 +1,12 @@
 import * as asserts from "std/testing/asserts.ts";
-import * as s from "../mod.ts";
+import * as $ from "../mod.ts";
 import { fixtures } from "../test-util.ts";
 
 Deno.test("Arrays", () => {
   fixtures.array_().forEach(([decoded, encoded, sizedEncoded]: [any[], Uint8Array, Uint8Array]) => {
-    asserts.assertEquals(s.array(s.u8).decode(encoded), decoded);
-    asserts.assertEquals(s.array(s.u8).encode(decoded), encoded);
-    asserts.assertEquals(s.sizedArray(s.u8, decoded.length).decode(sizedEncoded), decoded);
-    asserts.assertEquals(s.sizedArray(s.u8, decoded.length).encode(decoded), sizedEncoded);
+    asserts.assertEquals($.array($.u8).decode(encoded), decoded);
+    asserts.assertEquals($.array($.u8).encode(decoded), encoded);
+    asserts.assertEquals($.sizedArray($.u8, decoded.length).decode(sizedEncoded), decoded);
+    asserts.assertEquals($.sizedArray($.u8, decoded.length).encode(decoded), sizedEncoded);
   });
 });

--- a/bool/bench.ts
+++ b/bool/bench.ts
@@ -1,4 +1,4 @@
 import { benchCodec } from "../test-util.ts";
-import * as s from "./codec.ts";
+import * as $ from "./codec.ts";
 
-benchCodec("bool", s.bool, true);
+benchCodec("bool", $.bool, true);

--- a/bool/test.ts
+++ b/bool/test.ts
@@ -1,10 +1,10 @@
 import * as asserts from "std/testing/asserts.ts";
-import * as s from "../mod.ts";
+import * as $ from "../mod.ts";
 import * as f from "../test-util.ts";
 
 Deno.test("Booleans", () => {
   f.visitFixtures(f.fixtures.bool_, (bytes, decoded) => {
-    asserts.assertEquals(s.bool.decode(bytes), decoded);
-    asserts.assertEquals(s.bool.encode(decoded), bytes);
+    asserts.assertEquals($.bool.decode(bytes), decoded);
+    asserts.assertEquals($.bool.encode(decoded), bytes);
   }, f.constrainedIdentity<boolean>());
 });

--- a/compact/bench.ts
+++ b/compact/bench.ts
@@ -1,8 +1,8 @@
 import { benchCodec } from "../test-util.ts";
-import * as s from "./codec.ts";
+import * as $ from "./codec.ts";
 
-benchCodec("compact (u8)", s.compact, 2 ** (8 - 2) - 1);
-benchCodec("compact (u16)", s.compact, 2 ** (16 - 2) - 1);
-benchCodec("compact (u32)", s.compact, 2 ** (32 - 2) - 1);
-benchCodec("compact (b64)", s.compact, 2n ** 64n - 1n);
-benchCodec("compact (b128)", s.compact, 2n ** 128n - 1n);
+benchCodec("compact (u8)", $.compact, 2 ** (8 - 2) - 1);
+benchCodec("compact (u16)", $.compact, 2 ** (16 - 2) - 1);
+benchCodec("compact (u32)", $.compact, 2 ** (32 - 2) - 1);
+benchCodec("compact (b64)", $.compact, 2n ** 64n - 1n);
+benchCodec("compact (b128)", $.compact, 2n ** 128n - 1n);

--- a/compact/test.ts
+++ b/compact/test.ts
@@ -1,17 +1,17 @@
 import * as asserts from "std/testing/asserts.ts";
-import * as s from "../mod.ts";
+import * as $ from "../mod.ts";
 import * as f from "../test-util.ts";
 
 Deno.test("Number Compacts", () => {
   f.visitFixtures(f.fixtures.number_compact_, (bytes, decoded) => {
-    asserts.assertEquals(s.compact.decode(bytes), decoded);
-    asserts.assertEquals(s.compact.encode(decoded), bytes);
+    asserts.assertEquals($.compact.decode(bytes), decoded);
+    asserts.assertEquals($.compact.encode(decoded), bytes);
   }, f.constrainedIdentity<number>());
 });
 
 Deno.test("Bigint Compacts", () => {
   f.visitFixtures(f.fixtures.bigint_compact_, (bytes, decoded) => {
-    asserts.assertEquals(BigInt(s.compact.decode(bytes)), BigInt(decoded));
-    asserts.assertEquals(s.compact.encode(decoded), bytes);
+    asserts.assertEquals(BigInt($.compact.decode(bytes)), BigInt(decoded));
+    asserts.assertEquals($.compact.encode(decoded), bytes);
   }, f.constrainedIdentity<bigint>());
 });

--- a/dummy/bench.ts
+++ b/dummy/bench.ts
@@ -1,5 +1,5 @@
-import * as s from "../mod.ts";
+import * as $ from "../mod.ts";
 import { benchCodec } from "../test-util.ts";
 
 // Useful for testing overhead of Codec
-benchCodec("dummy", s.dummy(null), null);
+benchCodec("dummy", $.dummy(null), null);

--- a/dummy/test.ts
+++ b/dummy/test.ts
@@ -1,8 +1,8 @@
 import * as asserts from "std/testing/asserts.ts";
-import * as s from "../mod.ts";
+import * as $ from "../mod.ts";
 
 Deno.test("Dummy", () => {
-  const c = s.dummy<typeof s.i8>(101);
+  const c = $.dummy<typeof $.i8>(101);
   const encoded = c.encode(undefined as any);
   asserts.assertEquals(encoded, new Uint8Array([]));
   const decoded = c.decode(new Uint8Array([]));

--- a/instance/codec.ts
+++ b/instance/codec.ts
@@ -1,7 +1,7 @@
 import { Codec, Entries, Native } from "../common.ts";
 import { Field, NativeRecord, record } from "../record/codec.ts";
 
-export class Instance<Ctor extends new(...args: any[]) => any> extends Codec<InstanceType<Ctor>> {
+export class InstanceCodec<Ctor extends new(...args: any[]) => any> extends Codec<InstanceType<Ctor>> {
   constructor(
     ctor: Ctor,
     ...fields: Entries<InstanceType<Ctor>>
@@ -43,5 +43,5 @@ export const instance = <
   ctor: Ctor,
   ...fields: Fields
 ) => {
-  return new Instance(ctor, ...(fields as any));
+  return new InstanceCodec(ctor, ...(fields as any));
 };

--- a/instance/test.ts
+++ b/instance/test.ts
@@ -49,14 +49,14 @@ namespace _typeTests {
   // @ts-ignore: Prevent execution
   if (1 as 0) return;
 
-  let sPayload = $.record(
+  const $payload = $.record(
     ["a", $.str],
     ["b", $.u8],
     ["c", $.bool],
   );
 
   // ok
-  $.instance(MyError, ["code", $.u8], ["message", $.str], ["payload", sPayload]);
+  $.instance(MyError, ["code", $.u8], ["message", $.str], ["payload", $payload]);
 
   // @ts-expect-error: Missing constructor parameters
   $.instance(MyError);
@@ -65,8 +65,8 @@ namespace _typeTests {
   $.instance(MyError, ["code", $.u8], ["message", $.str], ["name", $.str]);
 
   // @ts-expect-error: Missing field
-  $.instance(MyError, ["code", $.u8], ["message", $.str], ["paidload", sPayload]);
+  $.instance(MyError, ["code", $.u8], ["message", $.str], ["paidload", $payload]);
 
   // @ts-expect-error: Field type mismatch
-  $.instance(MyError, ["code", $.u8], ["message", $.str], ["name", sPayload]);
+  $.instance(MyError, ["code", $.u8], ["message", $.str], ["name", $payload]);
 }

--- a/instance/test.ts
+++ b/instance/test.ts
@@ -1,5 +1,5 @@
 import * as asserts from "std/testing/asserts.ts";
-import * as s from "../mod.ts";
+import * as $ from "../mod.ts";
 
 class MyError extends Error {
   constructor(
@@ -16,16 +16,16 @@ class MyError extends Error {
 }
 
 Deno.test("Instances", () => {
-  const c = s.instance(
+  const c = $.instance(
     MyError,
-    ["code", s.u8],
-    ["message", s.str],
+    ["code", $.u8],
+    ["message", $.str],
     [
       "payload",
-      s.record(
-        ["a", s.str],
-        ["b", s.u8],
-        ["c", s.bool],
+      $.record(
+        ["a", $.str],
+        ["b", $.u8],
+        ["c", $.bool],
       ),
     ],
   );
@@ -49,24 +49,24 @@ namespace _typeTests {
   // @ts-ignore: Prevent execution
   if (1 as 0) return;
 
-  let sPayload = s.record(
-    ["a", s.str],
-    ["b", s.u8],
-    ["c", s.bool],
+  let sPayload = $.record(
+    ["a", $.str],
+    ["b", $.u8],
+    ["c", $.bool],
   );
 
   // ok
-  s.instance(MyError, ["code", s.u8], ["message", s.str], ["payload", sPayload]);
+  $.instance(MyError, ["code", $.u8], ["message", $.str], ["payload", sPayload]);
 
   // @ts-expect-error: Missing constructor parameters
-  s.instance(MyError);
+  $.instance(MyError);
 
   // @ts-expect-error: Constructor parameter type mismatch
-  s.instance(MyError, ["code", s.u8], ["message", s.str], ["name", s.str]);
+  $.instance(MyError, ["code", $.u8], ["message", $.str], ["name", $.str]);
 
   // @ts-expect-error: Missing field
-  s.instance(MyError, ["code", s.u8], ["message", s.str], ["paidload", sPayload]);
+  $.instance(MyError, ["code", $.u8], ["message", $.str], ["paidload", sPayload]);
 
   // @ts-expect-error: Field type mismatch
-  s.instance(MyError, ["code", s.u8], ["message", s.str], ["name", sPayload]);
+  $.instance(MyError, ["code", $.u8], ["message", $.str], ["name", sPayload]);
 }

--- a/int/bench.ts
+++ b/int/bench.ts
@@ -1,14 +1,14 @@
 import { benchCodec } from "../test-util.ts";
-import * as s from "./codec.ts";
+import * as $ from "./codec.ts";
 
-benchCodec("u8", s.u8, 123);
-benchCodec("u16", s.u16, 123);
-benchCodec("u32", s.u32, 123);
-benchCodec("u64", s.u64, 123n);
-benchCodec("u128", s.u128, 123n);
+benchCodec("u8", $.u8, 123);
+benchCodec("u16", $.u16, 123);
+benchCodec("u32", $.u32, 123);
+benchCodec("u64", $.u64, 123n);
+benchCodec("u128", $.u128, 123n);
 
-benchCodec("i8", s.i8, 123);
-benchCodec("i16", s.i16, 123);
-benchCodec("i32", s.i32, 123);
-benchCodec("i64", s.i64, 123n);
-benchCodec("i128", s.i128, 123n);
+benchCodec("i8", $.i8, 123);
+benchCodec("i16", $.i16, 123);
+benchCodec("i32", $.i32, 123);
+benchCodec("i64", $.i64, 123n);
+benchCodec("i128", $.i128, 123n);

--- a/int/codec.ts
+++ b/int/codec.ts
@@ -37,7 +37,7 @@ export const u64 = new NumCodec(8, "BigUint64");
 export const i64 = new NumCodec(8, "BigInt64");
 
 // https://github.com/unstoppablejs/unstoppablejs/blob/7022e34f756ccc25e6ed9d4680284455b2ff714b/packages/scale-ts/src/codecs/fixed-width-ints.ts#L59-L74
-class X128 extends Codec<bigint> {
+class X128Codec extends Codec<bigint> {
   constructor(signed: boolean) {
     super(
       () => {
@@ -51,14 +51,14 @@ class X128 extends Codec<bigint> {
       (cursor) => {
         const right = cursor.view.getBigUint64(cursor.i, true);
         const left = cursor.view[
-          signed ? 'getBigInt64' : 'getBigUint64'
+          signed ? "getBigInt64" : "getBigUint64"
         ](cursor.i + 8, true);
-        cursor.i += 16
+        cursor.i += 16;
         return (left << 64n) | right;
       },
     );
   }
 }
 
-export const u128 = new X128(false);
-export const i128 = new X128(true);
+export const u128 = new X128Codec(false);
+export const i128 = new X128Codec(true);

--- a/int/test.ts
+++ b/int/test.ts
@@ -1,73 +1,73 @@
 import * as asserts from "std/testing/asserts.ts";
-import * as s from "../mod.ts";
+import * as $ from "../mod.ts";
 import * as f from "../test-util.ts";
 
 Deno.test("U8s", () => {
   f.visitFixtures(f.fixtures.u8_, (bytes, decoded) => {
-    asserts.assertEquals(s.u8.decode(bytes), decoded);
-    asserts.assertEquals(s.u8.encode(decoded), bytes);
+    asserts.assertEquals($.u8.decode(bytes), decoded);
+    asserts.assertEquals($.u8.encode(decoded), bytes);
   }, f.constrainedIdentity<number>());
 });
 
 Deno.test("I8s", () => {
   f.visitFixtures(f.fixtures.i8_, (bytes, decoded) => {
-    asserts.assertEquals(s.i8.decode(bytes), decoded);
-    asserts.assertEquals(s.i8.encode(decoded), bytes);
+    asserts.assertEquals($.i8.decode(bytes), decoded);
+    asserts.assertEquals($.i8.encode(decoded), bytes);
   }, f.constrainedIdentity<number>());
 });
 
 Deno.test("U16s", () => {
   f.visitFixtures(f.fixtures.u16_, (bytes, decoded) => {
-    asserts.assertEquals(s.u16.decode(bytes), decoded);
-    asserts.assertEquals(s.u16.encode(decoded), bytes);
+    asserts.assertEquals($.u16.decode(bytes), decoded);
+    asserts.assertEquals($.u16.encode(decoded), bytes);
   }, f.constrainedIdentity<number>());
 });
 
 Deno.test("I16s", () => {
   f.visitFixtures(f.fixtures.i16_, (bytes, decoded) => {
-    asserts.assertEquals(s.i16.decode(bytes), decoded);
-    asserts.assertEquals(s.i16.encode(decoded), bytes);
+    asserts.assertEquals($.i16.decode(bytes), decoded);
+    asserts.assertEquals($.i16.encode(decoded), bytes);
   }, f.constrainedIdentity<number>());
 });
 
 Deno.test("U32s", () => {
   f.visitFixtures(f.fixtures.u32_, (bytes, decoded) => {
-    asserts.assertEquals(s.u32.decode(bytes), decoded);
-    asserts.assertEquals(s.u32.encode(decoded), bytes);
+    asserts.assertEquals($.u32.decode(bytes), decoded);
+    asserts.assertEquals($.u32.encode(decoded), bytes);
   }, f.constrainedIdentity<number>());
 });
 
 Deno.test("I32s", () => {
   f.visitFixtures(f.fixtures.i32_, (bytes, decoded) => {
-    asserts.assertEquals(s.i32.decode(bytes), decoded);
-    asserts.assertEquals(s.i32.encode(decoded), bytes);
+    asserts.assertEquals($.i32.decode(bytes), decoded);
+    asserts.assertEquals($.i32.encode(decoded), bytes);
   }, f.constrainedIdentity<number>());
 });
 
 Deno.test("U64s", () => {
   f.visitFixtures(f.fixtures.u64_, (bytes, decoded) => {
-    asserts.assertEquals(s.u64.decode(bytes), decoded);
-    asserts.assertEquals(s.u64.encode(decoded), bytes);
+    asserts.assertEquals($.u64.decode(bytes), decoded);
+    asserts.assertEquals($.u64.encode(decoded), bytes);
   }, f.constrainedIdentity<bigint>());
 });
 
 Deno.test("I64s", () => {
   f.visitFixtures(f.fixtures.i64_, (bytes, decoded) => {
-    asserts.assertEquals(s.i64.decode(bytes), decoded);
-    asserts.assertEquals(s.i64.encode(decoded), bytes);
+    asserts.assertEquals($.i64.decode(bytes), decoded);
+    asserts.assertEquals($.i64.encode(decoded), bytes);
   }, f.constrainedIdentity<bigint>());
 });
 
 Deno.test("U128s", () => {
   f.visitFixtures(f.fixtures.u128_, (bytes, decoded) => {
-    asserts.assertEquals(s.u128.decode(bytes), decoded);
-    asserts.assertEquals(s.u128.encode(decoded), bytes);
+    asserts.assertEquals($.u128.decode(bytes), decoded);
+    asserts.assertEquals($.u128.encode(decoded), bytes);
   }, f.constrainedIdentity<bigint>());
 });
 
 Deno.test("I128s", () => {
   f.visitFixtures(f.fixtures.i128_, (bytes, decoded) => {
-    asserts.assertEquals(s.i128.decode(bytes), decoded);
-    asserts.assertEquals(s.i128.encode(decoded), bytes);
+    asserts.assertEquals($.i128.decode(bytes), decoded);
+    asserts.assertEquals($.i128.encode(decoded), bytes);
   }, f.constrainedIdentity<bigint>());
 });

--- a/option/bench.ts
+++ b/option/bench.ts
@@ -1,8 +1,8 @@
-import * as s from "../mod.ts";
+import * as $ from "../mod.ts";
 import { benchCodec } from "../test-util.ts";
 
-benchCodec("None<bool>", s.option(s.bool), undefined);
-benchCodec("None<u128>", s.option(s.u128), undefined);
+benchCodec("None<bool>", $.option($.bool), undefined);
+benchCodec("None<u128>", $.option($.u128), undefined);
 
-benchCodec("Some<bool>", s.option(s.bool), true);
-benchCodec("Some<u128>", s.option(s.u128), 12345678901234567890n);
+benchCodec("Some<bool>", $.option($.bool), true);
+benchCodec("Some<u128>", $.option($.u128), 12345678901234567890n);

--- a/option/codec.ts
+++ b/option/codec.ts
@@ -1,7 +1,7 @@
 import { Codec } from "../common.ts";
 import { u8 } from "../int/codec.ts";
 
-export class Option<Some> extends Codec<Some | undefined> {
+export class OptionCodec<Some> extends Codec<Some | undefined> {
   constructor(someCodec: Codec<Some>) {
     super(
       (value) => {
@@ -30,6 +30,6 @@ export class Option<Some> extends Codec<Some | undefined> {
     );
   }
 }
-export const option = <Some>(someCodec: Codec<Some>): Option<Some> => {
-  return new Option(someCodec);
+export const option = <Some>(someCodec: Codec<Some>): OptionCodec<Some> => {
+  return new OptionCodec(someCodec);
 };

--- a/option/test.ts
+++ b/option/test.ts
@@ -1,17 +1,17 @@
 import * as asserts from "std/testing/asserts.ts";
-import * as s from "../mod.ts";
+import * as $ from "../mod.ts";
 import * as f from "../test-util.ts";
 
 Deno.test("Options", () => {
   f.visitFixtures(f.fixtures.option_, (bytes, decoded, i) => {
     // Be explicit with an `any` type arg so that inference doesn't produce contravariance issue pertaining to
     // `string` and `number` args of supplied codec's `_s` methods.
-    const o = s.option<any>(
+    const o = $.option<any>(
       {
-        0: s.str,
-        1: s.u8,
-        2: s.str,
-        3: s.u32,
+        0: $.str,
+        1: $.u8,
+        2: $.str,
+        3: $.u32,
         4: undefined,
       }[i]!,
     );
@@ -24,7 +24,7 @@ Deno.test("Options", () => {
 
 Deno.test("Boolean Options", () => {
   f.visitFixtures(f.fixtures.bool_option_, (bytes, decoded, i) => {
-    asserts.assertEquals(s.option(s.bool).decode(bytes), decoded);
-    asserts.assertEquals(s.option(s.bool).encode(decoded), bytes);
+    asserts.assertEquals($.option($.bool).decode(bytes), decoded);
+    asserts.assertEquals($.option($.bool).encode(decoded), bytes);
   }, f.constrainedIdentity<boolean | undefined>());
 });

--- a/record/bench.ts
+++ b/record/bench.ts
@@ -1,19 +1,19 @@
-import * as s from "../mod.ts";
+import * as $ from "../mod.ts";
 import { benchCodec } from "../test-util.ts";
 
 // for comparison
-benchCodec("u128", s.u128, 123n);
+benchCodec("u128", $.u128, 123n);
 
-benchCodec("{}", s.record(), {});
-benchCodec("{ x: u128 }", s.record(["x", s.u128]), { x: 123n });
+benchCodec("{}", $.record(), {});
+benchCodec("{ x: u128 }", $.record(["x", $.u128]), { x: 123n });
 benchCodec(
   "{ x: u128, y: u128 }",
-  s.record(["x", s.u128], ["y", s.u128]),
+  $.record(["x", $.u128], ["y", $.u128]),
   { x: 123n, y: 456n },
 );
 benchCodec(
   "{ x: u128, y: u128, z: u128 }",
-  s.record(["x", s.u128], ["y", s.u128], ["z", s.u128]),
+  $.record(["x", $.u128], ["y", $.u128], ["z", $.u128]),
   { x: 123n, y: 456n, z: 789n },
 );
 
@@ -21,4 +21,4 @@ const longKey =
   "thisIsTheKeyThatNeverEnds_itJustGoesRoundAndRoundMyFriends_somePeopleStartedWritingIt_notKnowingWhatItWas_andWeContinueWritingItForeverJustBecause_"
     .repeat(1000);
 
-benchCodec("{ [longKey]: u128 }", s.record([longKey, s.u128]), { [longKey]: 123n });
+benchCodec("{ [longKey]: u128 }", $.record([longKey, $.u128]), { [longKey]: 123n });

--- a/record/codec.ts
+++ b/record/codec.ts
@@ -13,7 +13,7 @@ export type NativeRecord<Fields extends Field[]> = Fields extends [] ? {}
     ? { [_ in K]: Native<V> } & (Rest extends Field[] ? NativeRecord<Rest> : {})
   : never;
 
-export class Record<Fields extends Field[]> extends Codec<Flatten<NativeRecord<Fields>>> {
+export class RecordCodec<Fields extends Field[]> extends Codec<Flatten<NativeRecord<Fields>>> {
   constructor(...fields: Fields) {
     super(
       (value) => {
@@ -41,6 +41,6 @@ export const record = <
   Fields extends Field<EntryKey, EntryValueCodec>[],
   EntryKey extends PropertyKey,
   EntryValueCodec extends Codec,
->(...fields: Fields): Record<Fields> => {
-  return new Record(...fields);
+>(...fields: Fields): RecordCodec<Fields> => {
+  return new RecordCodec(...fields);
 };

--- a/record/test.ts
+++ b/record/test.ts
@@ -1,13 +1,13 @@
 import * as asserts from "std/testing/asserts.ts";
-import * as s from "../mod.ts";
+import * as $ from "../mod.ts";
 import * as f from "../test-util.ts";
 
 Deno.test("Records", () => {
-  const c = s.record(
-    ["name", s.str],
-    ["nickName", s.str],
-    ["superPower", s.option(s.str)],
-    ["luckyNumber", s.u8],
+  const c = $.record(
+    ["name", $.str],
+    ["nickName", $.str],
+    ["superPower", $.option($.str)],
+    ["luckyNumber", $.u8],
   );
   f.visitFixtures(f.fixtures.record_, (bytes, decoded) => {
     asserts.assertEquals(c.decode(bytes), decoded);

--- a/result/codec.ts
+++ b/result/codec.ts
@@ -1,14 +1,14 @@
 import { Codec } from "../common.ts";
-import { Instance } from "../instance/codec.ts";
-import { Union } from "../union/codec.ts";
+import { InstanceCodec } from "../instance/codec.ts";
+import { UnionCodec } from "../union/codec.ts";
 
-export class Result<
+export class ResultCodec<
   Ok,
   Err extends Error,
-> extends Union<[Ok, Err]> {
+> extends UnionCodec<[Ok, Err]> {
   constructor(
     okCodec: Codec<Ok>,
-    errCodec: Instance<new(...args: any[]) => Err>,
+    errCodec: InstanceCodec<new(...args: any[]) => Err>,
   ) {
     super(
       (value) => {
@@ -24,7 +24,7 @@ export const result = <
   Err extends Error,
 >(
   okCodec: Codec<Ok>,
-  errCodec: Instance<new(...args: any[]) => any>,
-): Result<Ok, Err> => {
-  return new Result(okCodec, errCodec);
+  errCodec: InstanceCodec<new(...args: any[]) => any>,
+): ResultCodec<Ok, Err> => {
+  return new ResultCodec(okCodec, errCodec);
 };

--- a/result/test.ts
+++ b/result/test.ts
@@ -1,5 +1,5 @@
 import * as asserts from "std/testing/asserts.ts";
-import * as s from "../mod.ts";
+import * as $ from "../mod.ts";
 import { fixtures, visitFixtures } from "../test-util.ts";
 
 class ErrFromTuple extends Error {
@@ -33,7 +33,7 @@ Deno.test("Results", () => {
       case 0:
       case 1:
       case 2: {
-        const c = s.result(s.record(["value", s.str]), undefined as any);
+        const c = $.result($.record(["value", $.str]), undefined as any);
         asserts.assertEquals(c.decode(bytes), decoded);
         asserts.assertEquals(c.encode(decoded as any), bytes);
         break;
@@ -41,7 +41,7 @@ Deno.test("Results", () => {
       case 3:
       case 4:
       case 5: {
-        const c = s.result(undefined as any, s.instance(ErrFromValue, ["value", s.str]));
+        const c = $.result(undefined as any, $.instance(ErrFromValue, ["value", $.str]));
         const d = c.decode(bytes);
         asserts.assert(d instanceof ErrFromValue);
         asserts.assertEquals(d.value, (decoded as ErrFromValue).value);
@@ -49,7 +49,7 @@ Deno.test("Results", () => {
         break;
       }
       case 6: {
-        const c = s.result(undefined as any, s.instance(ErrFromTuple, ["a", s.str], ["b", s.str]));
+        const c = $.result(undefined as any, $.instance(ErrFromTuple, ["a", $.str], ["b", $.str]));
         const d = c.decode(bytes);
         asserts.assert(d instanceof ErrFromTuple);
         asserts.assertEquals(d.a, (decoded as any).a);
@@ -57,7 +57,7 @@ Deno.test("Results", () => {
         break;
       }
       case 7: {
-        const c = s.result(undefined as any, s.instance(ErrFromObj, ["data", s.record(["x", s.str])]));
+        const c = $.result(undefined as any, $.instance(ErrFromObj, ["data", $.record(["x", $.str])]));
         const d = c.decode(bytes);
         asserts.assert(d instanceof ErrFromObj);
         asserts.assertEquals(d.data, (decoded as ErrFromObj).data);

--- a/str/bench.ts
+++ b/str/bench.ts
@@ -1,5 +1,5 @@
 import { dirname, join } from "std/path/mod.ts";
-import * as s from "../mod.ts";
+import * as $ from "../mod.ts";
 import { benchCodec } from "../test-util.ts";
 
 const trolleybus = "🚎";
@@ -7,14 +7,14 @@ const special = "œ∑é®†¥üîøπåß∂ƒ©˙∆˚¬Ω≈ç√∫ñµ";
 const lipsum = await fetch(join(dirname(import.meta.url), "../lipsum.txt")).then((x) => x.text());
 const cargoLock = await fetch(join(dirname(import.meta.url), "../Cargo.lock")).then((x) => x.text());
 
-benchCodec(`""`, s.str, "");
-benchCodec(`"abc"`, s.str, "abc");
-benchCodec(`trolleybus`, s.str, trolleybus);
-benchCodec(`special`, s.str, special);
-benchCodec(`lipsum`, s.str, lipsum);
-benchCodec(`cargoLock`, s.str, cargoLock);
-benchCodec(`"abc" * 1000`, s.str, "abc".repeat(1000));
-benchCodec(`trolleybus * 1000`, s.str, trolleybus.repeat(1000));
-benchCodec(`special * 1000`, s.str, special.repeat(1000));
-benchCodec(`lipsum * 1000`, s.str, lipsum.repeat(1000));
-benchCodec(`cargoLock * 1000`, s.str, cargoLock.repeat(1000));
+benchCodec(`""`, $.str, "");
+benchCodec(`"abc"`, $.str, "abc");
+benchCodec(`trolleybus`, $.str, trolleybus);
+benchCodec(`special`, $.str, special);
+benchCodec(`lipsum`, $.str, lipsum);
+benchCodec(`cargoLock`, $.str, cargoLock);
+benchCodec(`"abc" * 1000`, $.str, "abc".repeat(1000));
+benchCodec(`trolleybus * 1000`, $.str, trolleybus.repeat(1000));
+benchCodec(`special * 1000`, $.str, special.repeat(1000));
+benchCodec(`lipsum * 1000`, $.str, lipsum.repeat(1000));
+benchCodec(`cargoLock * 1000`, $.str, cargoLock.repeat(1000));

--- a/str/test.ts
+++ b/str/test.ts
@@ -1,10 +1,10 @@
 import * as asserts from "std/testing/asserts.ts";
-import * as s from "../mod.ts";
+import * as $ from "../mod.ts";
 import * as f from "../test-util.ts";
 
 Deno.test("Strings", () => {
   f.visitFixtures(f.fixtures.str_, (bytes, decoded) => {
-    asserts.assertEquals(s.str.decode(bytes), decoded);
-    asserts.assertEquals(s.str.encode(decoded), bytes);
+    asserts.assertEquals($.str.decode(bytes), decoded);
+    asserts.assertEquals($.str.encode(decoded), bytes);
   }, f.constrainedIdentity<string>());
 });

--- a/tuple/bench.ts
+++ b/tuple/bench.ts
@@ -1,10 +1,10 @@
-import * as s from "../mod.ts";
+import * as $ from "../mod.ts";
 import { benchCodec } from "../test-util.ts";
 
 // for comparison
-benchCodec("u128", s.u128, 123n);
+benchCodec("u128", $.u128, 123n);
 
-benchCodec("[]", s.tuple(), []);
-benchCodec("[u128]", s.tuple(s.u128), [123n]);
-benchCodec("[u128, u128]", s.tuple(s.u128, s.u128), [123n, 456n]);
-benchCodec("[u128, u128, u128]", s.tuple(s.u128, s.u128, s.u128), [123n, 456n, 789n]);
+benchCodec("[]", $.tuple(), []);
+benchCodec("[u128]", $.tuple($.u128), [123n]);
+benchCodec("[u128, u128]", $.tuple($.u128, $.u128), [123n, 456n]);
+benchCodec("[u128, u128, u128]", $.tuple($.u128, $.u128, $.u128), [123n, 456n, 789n]);

--- a/tuple/codec.ts
+++ b/tuple/codec.ts
@@ -4,7 +4,7 @@ export type NativeTuple<ElCodecs extends Codec[]> = {
   [I in keyof ElCodecs]: ElCodecs[I] extends Codec<infer T> ? T : never;
 };
 
-export class Tuple<ElCodecs extends Codec[] = Codec[]> extends Codec<NativeTuple<ElCodecs>> {
+export class TupleCodec<ElCodecs extends Codec[] = Codec[]> extends Codec<NativeTuple<ElCodecs>> {
   constructor(...elCodecs: ElCodecs) {
     super(
       (value) => {
@@ -29,6 +29,6 @@ export class Tuple<ElCodecs extends Codec[] = Codec[]> extends Codec<NativeTuple
   }
 }
 
-export const tuple = <ElCodecs extends Codec[]>(...elCodecs: ElCodecs): Tuple<ElCodecs> => {
-  return new Tuple(...elCodecs);
+export const tuple = <ElCodecs extends Codec[]>(...elCodecs: ElCodecs): TupleCodec<ElCodecs> => {
+  return new TupleCodec(...elCodecs);
 };

--- a/tuple/test.ts
+++ b/tuple/test.ts
@@ -7,7 +7,7 @@ Deno.test("Tuples", () => {
     const t = $.tuple(
       ...{
         0: [$.str, $.u8, $.str, $.u32],
-        1: [$.str, $.i16, new $.Option($.u16)],
+        1: [$.str, $.i16, new $.OptionCodec($.u16)],
       }[i]!,
     );
     asserts.assertEquals(t.decode(bytes), decoded);

--- a/tuple/test.ts
+++ b/tuple/test.ts
@@ -1,13 +1,13 @@
 import * as asserts from "std/testing/asserts.ts";
-import * as s from "../mod.ts";
+import * as $ from "../mod.ts";
 import * as f from "../test-util.ts";
 
 Deno.test("Tuples", () => {
   f.visitFixtures(f.fixtures.tuple_, (bytes, decoded, i) => {
-    const t = s.tuple(
+    const t = $.tuple(
       ...{
-        0: [s.str, s.u8, s.str, s.u32],
-        1: [s.str, s.i16, new s.Option(s.u16)],
+        0: [$.str, $.u8, $.str, $.u32],
+        1: [$.str, $.i16, new $.Option($.u16)],
       }[i]!,
     );
     asserts.assertEquals(t.decode(bytes), decoded);

--- a/union/codec.ts
+++ b/union/codec.ts
@@ -3,7 +3,7 @@ import { u8 } from "../int/codec.ts";
 
 export type NativeUnion<MemberCodecs extends Codec[] = Codec[]> = Native<MemberCodecs[number]>;
 
-export class Union<Members extends any[]> extends Codec<Members[number]> {
+export class UnionCodec<Members extends any[]> extends Codec<Members[number]> {
   constructor(
     discriminate: (value: Members[number]) => number,
     ...memberCodecs: CodecList<Members>
@@ -32,6 +32,6 @@ export class Union<Members extends any[]> extends Codec<Members[number]> {
 export const union = <Members extends any[]>(
   discriminate: (value: Members[number]) => number,
   ...memberCodecs: CodecList<Members>
-): Union<Members> => {
-  return new Union(discriminate, ...memberCodecs);
+): UnionCodec<Members> => {
+  return new UnionCodec(discriminate, ...memberCodecs);
 };

--- a/union/comparable_value/codec.ts
+++ b/union/comparable_value/codec.ts
@@ -1,10 +1,10 @@
 import { Codec } from "../../common.ts";
-import { Union } from "../../union/codec.ts";
+import { UnionCodec } from "../../union/codec.ts";
 
-export class ComparableValueUnion<
+export class ComparableValueUnionCodec<
   MemberWide,
   Member extends MemberWide,
-> extends Union<Member[]> {
+> extends UnionCodec<Member[]> {
   constructor(
     memberCodec: Codec<MemberWide>,
     ...members: Member[]
@@ -23,6 +23,6 @@ export const comparableValueUnion = <
 >(
   memberCodec: Codec<MemberWide>,
   ...members: Member[]
-): ComparableValueUnion<MemberWide, Member> => {
-  return new ComparableValueUnion(memberCodec, ...members);
+): ComparableValueUnionCodec<MemberWide, Member> => {
+  return new ComparableValueUnionCodec(memberCodec, ...members);
 };

--- a/union/comparable_value/test.ts
+++ b/union/comparable_value/test.ts
@@ -1,5 +1,5 @@
 import * as asserts from "std/testing/asserts.ts";
-import * as s from "../../mod.ts";
+import * as $ from "../../mod.ts";
 
 Deno.test("Comparable Value Union", () => {
   enum X {
@@ -7,7 +7,7 @@ Deno.test("Comparable Value Union", () => {
     B = "B",
     C = "C",
   }
-  const c = s.comparableValueUnion(s.str, X.A, X.B, X.C);
+  const c = $.comparableValueUnion($.str, X.A, X.B, X.C);
 
   const aBytes = c.encode(X.A);
   const aDecoded = c.decode(aBytes);

--- a/union/implicit_init_num_enum/codec.ts
+++ b/union/implicit_init_num_enum/codec.ts
@@ -2,7 +2,7 @@ import { Codec } from "../../common.ts";
 import { u8 } from "../../int/codec.ts";
 
 // TODO: decide whether to pursue further static-type-level safeguards
-export class OrderedNumEnum<Enum> extends Codec<Enum[keyof Enum]> {
+export class OrderedNumEnumCodec<Enum> extends Codec<Enum[keyof Enum]> {
   constructor(enum_: Enum) {
     super(
       () => {
@@ -19,6 +19,6 @@ export class OrderedNumEnum<Enum> extends Codec<Enum[keyof Enum]> {
     );
   }
 }
-export const orderedNumEnum = <Enum>(enum_: Enum): OrderedNumEnum<Enum> => {
-  return new OrderedNumEnum(enum_);
+export const orderedNumEnum = <Enum>(enum_: Enum): OrderedNumEnumCodec<Enum> => {
+  return new OrderedNumEnumCodec(enum_);
 };

--- a/union/key/codec.ts
+++ b/union/key/codec.ts
@@ -1,7 +1,7 @@
 import { Codec } from "../../common.ts";
 import { u8 } from "../../int/codec.ts";
 
-export class KeyLiteralUnion<Member extends PropertyKey> extends Codec<Member> {
+export class KeyLiteralUnionCodec<Member extends PropertyKey> extends Codec<Member> {
   constructor(...members: Member[]) {
     const discriminantByKey = members.reduce<Partial<Record<Member, number>>>((acc, cur, i) => {
       return {
@@ -24,6 +24,6 @@ export class KeyLiteralUnion<Member extends PropertyKey> extends Codec<Member> {
     );
   }
 }
-export const keyLiteralUnion = <Member extends PropertyKey>(...members: Member[]): KeyLiteralUnion<Member> => {
-  return new KeyLiteralUnion(...members);
+export const keyLiteralUnion = <Member extends PropertyKey>(...members: Member[]): KeyLiteralUnionCodec<Member> => {
+  return new KeyLiteralUnionCodec(...members);
 };

--- a/union/tagged/codec.ts
+++ b/union/tagged/codec.ts
@@ -1,7 +1,7 @@
 import { Codec, Flatten } from "../../common.ts";
 import { dummy } from "../../dummy/codec.ts";
 import { Field, NativeRecord, record } from "../../record/codec.ts";
-import { Union } from "../../union/codec.ts";
+import { UnionCodec } from "../../union/codec.ts";
 
 export type TaggedUnionMember<
   MemberTag extends PropertyKey = PropertyKey,
@@ -20,15 +20,15 @@ export type NativeTaggedUnionMembers<
   TagKey extends PropertyKey,
   M extends TaggedUnionMember[],
 > = M extends [] ? never
-  : M extends [infer E0, ...infer ERest] ?
+  : M extends [infer E0, ...infer ERest] ? 
     | (E0 extends TaggedUnionMember ? NativeTaggedUnionMember<TagKey, E0> : never)
     | (ERest extends TaggedUnionMember[] ? NativeTaggedUnionMembers<TagKey, ERest> : never)
   : never;
 
-export class TaggedUnion<
+export class TaggedUnionCodec<
   TagKey extends PropertyKey,
   Members extends TaggedUnionMember[],
-> extends Union<Flatten<NativeTaggedUnionMembers<TagKey, Members>>[]> {
+> extends UnionCodec<Flatten<NativeTaggedUnionMembers<TagKey, Members>>[]> {
   constructor(
     tagKey: TagKey,
     ...members: Members
@@ -58,6 +58,6 @@ export const taggedUnion = <
 >(
   tagKey: TagKey,
   ...members: Members
-): TaggedUnion<TagKey, Members> => {
-  return new TaggedUnion(tagKey, ...members);
+): TaggedUnionCodec<TagKey, Members> => {
+  return new TaggedUnionCodec(tagKey, ...members);
 };

--- a/union/tagged/test.ts
+++ b/union/tagged/test.ts
@@ -1,18 +1,18 @@
 import * as asserts from "std/testing/asserts.ts";
-import * as s from "../../mod.ts";
+import * as $ from "../../mod.ts";
 import * as f from "../../test-util.ts";
 
 Deno.test("Unions", () => {
-  const c = s.taggedUnion(
+  const c = $.taggedUnion(
     "_tag",
     ["A"],
-    ["B", ["B", s.str]],
-    ["C", ["C", s.tuple(s.u32, s.u64)]],
+    ["B", ["B", $.str]],
+    ["C", ["C", $.tuple($.u32, $.u64)]],
     ["D", [
       "D",
-      s.record(
-        ["a", s.u32],
-        ["b", s.u64],
+      $.record(
+        ["a", $.u32],
+        ["b", $.u64],
       ),
     ]],
   );

--- a/union/test.ts
+++ b/union/test.ts
@@ -1,9 +1,9 @@
 import * as asserts from "std/testing/asserts.ts";
-import * as s from "../mod.ts";
+import * as $ from "../mod.ts";
 import * as f from "../test-util.ts";
 
 Deno.test("Unions", () => {
-  const c = s.union(
+  const c = $.union(
     (value) => {
       return {
         A: 0,
@@ -12,22 +12,22 @@ Deno.test("Unions", () => {
         D: 3,
       }[value._tag];
     },
-    s.record(["_tag", s.dummy<s.Codec<"A">>("A")]),
-    s.record(
-      ["_tag", s.dummy<s.Codec<"B">>("B")],
-      ["B", s.str],
+    $.record(["_tag", $.dummy<$.Codec<"A">>("A")]),
+    $.record(
+      ["_tag", $.dummy<$.Codec<"B">>("B")],
+      ["B", $.str],
     ),
-    s.record(
-      ["_tag", s.dummy<s.Codec<"C">>("C")],
-      ["C", s.tuple(s.u32, s.u64)],
+    $.record(
+      ["_tag", $.dummy<$.Codec<"C">>("C")],
+      ["C", $.tuple($.u32, $.u64)],
     ),
-    s.record(
-      ["_tag", s.dummy<s.Codec<"D">>("D")],
+    $.record(
+      ["_tag", $.dummy<$.Codec<"D">>("D")],
       [
         "D",
-        s.record(
-          ["a", s.u32],
-          ["b", s.u64],
+        $.record(
+          ["a", $.u32],
+          ["b", $.u64],
         ),
       ],
     ),


### PR DESCRIPTION
Per discussion with @harrysolovay:
- The namespace import from scale is named `$`, and codecs thereof are referenced as e.g. `$.str`
- User-defined codecs are prefixed with `$` (e.g. `$person`)
- Codec subclasses are suffixed with `Codec` to avoid clashes (e.g. `ArrayCodec`)

Todo: explicitly speak to these conventions in the readme and provide rationale (best for a separate PR, I think)