### PR TITLE
Add `$.constantPattern`

### DIFF
--- a/constantPattern/__snapshots__/test.ts.snap
+++ b/constantPattern/__snapshots__/test.ts.snap
@@ -1,0 +1,12 @@
+export const snapshot = {};
+
+snapshot[`constantPattern 1635018093 1`] = `
+6d
+65
+74
+61
+`;
+
+snapshot[`constantPattern.encode throws 1`] = `"Invalid value; expected 1635018093, got 123"`;
+
+snapshot[`constantPattern.decode throws 1`] = `"Invalid pattern; expected 0x6d657461, got 0x7b000000"`;

--- a/constantPattern/codec.ts
+++ b/constantPattern/codec.ts
@@ -1,0 +1,36 @@
+import { Codec, createCodec } from "../common.ts";
+
+export function constantPattern<T>(value: T, codec: Codec<T>): Codec<T>;
+export function constantPattern<T>(value: T, pattern: Uint8Array): Codec<T>;
+export function constantPattern<T>(value: T, c: Codec<T> | Uint8Array): Codec<T> {
+  const pattern = c instanceof Uint8Array ? c : c.encode(value);
+  return createCodec<T>({
+    // We could set `_staticSize` to `pattern.length`, but in this case it will
+    // usually more efficient to insert `pattern` dynamically, rather than
+    // manually copy the bytes.
+    _staticSize: 0,
+    _encode(buffer, got) {
+      if (got !== value) {
+        throw new Error(`Invalid value; expected ${Deno.inspect(value)}, got ${Deno.inspect(got)}`);
+      }
+      buffer.insertArray(pattern);
+    },
+    _decode(buffer) {
+      const got = buffer.array.subarray(buffer.index, buffer.index += pattern.length);
+      for (let i = 0; i < pattern.length; i++) {
+        if (pattern[i] !== got[i]) {
+          throw new Error(`Invalid pattern; expected ${hex(pattern)}, got ${hex(got)}`);
+        }
+      }
+      return value;
+    },
+  });
+}
+
+function hex(pattern: Uint8Array) {
+  let str = "0x";
+  for (let i = 0; i < pattern.length; i++) {
+    str += pattern[i]!.toString(16).padStart(2, "0");
+  }
+  return str;
+}

--- a/constantPattern/codec.ts
+++ b/constantPattern/codec.ts
@@ -1,8 +1,8 @@
 import { Codec, createCodec } from "../common.ts";
 
-export function constantPattern<T>(value: T, codec: Codec<T>): Codec<T>;
+export function constantPattern<T>(value: T, codec: Pick<Codec<T>, "encode">): Codec<T>;
 export function constantPattern<T>(value: T, pattern: Uint8Array): Codec<T>;
-export function constantPattern<T>(value: T, c: Codec<T> | Uint8Array): Codec<T> {
+export function constantPattern<T>(value: T, c: Pick<Codec<T>, "encode"> | Uint8Array): Codec<T> {
   const pattern = c instanceof Uint8Array ? c : c.encode(value);
   return createCodec<T>({
     // We could set `_staticSize` to `pattern.length`, but in this case it will

--- a/constantPattern/test.ts
+++ b/constantPattern/test.ts
@@ -6,7 +6,7 @@ const $magicNumber = $.constantPattern(magicNumber, $.u32);
 testCodec("constantPattern", $magicNumber, [magicNumber]);
 
 Deno.test("constantPattern.encode throws", async (t) => {
-  await assertThrowsSnapshot(t, () => $magicNumber.encode(123));
+  await assertThrowsSnapshot(t, () => $magicNumber.encode(123 as any));
 });
 
 Deno.test("constantPattern.decode throws", async (t) => {

--- a/constantPattern/test.ts
+++ b/constantPattern/test.ts
@@ -1,0 +1,14 @@
+import * as $ from "../mod.ts";
+import { assertThrowsSnapshot, testCodec } from "../test-util.ts";
+
+const magicNumber = 0x6174656d;
+const $magicNumber = $.constantPattern(magicNumber, $.u32);
+testCodec("constantPattern", $magicNumber, [magicNumber]);
+
+Deno.test("constantPattern.encode throws", async (t) => {
+  await assertThrowsSnapshot(t, () => $magicNumber.encode(123));
+});
+
+Deno.test("constantPattern.decode throws", async (t) => {
+  await assertThrowsSnapshot(t, () => $magicNumber.decode($.u32.encode(123)));
+});

--- a/mod.ts
+++ b/mod.ts
@@ -2,6 +2,7 @@ export * from "./array/codec.ts";
 export * from "./bool/codec.ts";
 export * from "./common.ts";
 export * from "./compact/codec.ts";
+export * from "./constantPattern/codec.ts";
 export * from "./deferred/codec.ts";
 export * from "./dummy/codec.ts";
 export * from "./instance/codec.ts";

--- a/test-util.ts
+++ b/test-util.ts
@@ -45,3 +45,12 @@ export function benchCodec<T>(name: string, codec: Codec<T>, value: T) {
     codec.decode(encoded);
   });
 }
+
+export async function assertThrowsSnapshot(t: Deno.TestContext, fn: () => unknown) {
+  try {
+    fn();
+  } catch (e) {
+    return await assertSnapshot(t, e.message);
+  }
+  throw new Error("Expected function to throw");
+}


### PR DESCRIPTION
Useful for things like the [magic number in FRAME Metadata](https://docs.substrate.io/v3/runtime/metadata/#encoded-metadata-format)