### PR TITLE
Add metadata and visitors

### DIFF
--- a/__snapshots__/common.test.ts.snap
+++ b/__snapshots__/common.test.ts.snap
@@ -1,0 +1,3 @@
+export const snapshot = {};
+
+snapshot[`CodecVisitor 1`] = `"Unrecognized codec"`;

--- a/array/codec.ts
+++ b/array/codec.ts
@@ -9,8 +9,9 @@ type ArrayOfLength<
   : L extends A["length"] ? A
   : ArrayOfLength<T, L, [...A, T]>;
 
-export function sizedArray<L extends number, T>($el: Codec<T>, length: L) {
-  return createCodec<ArrayOfLength<T, L>>({
+export function sizedArray<L extends number, T>($el: Codec<T>, length: L): Codec<ArrayOfLength<T, L>> {
+  return createCodec({
+    _metadata: [sizedArray, $el, length],
     _staticSize: $el._staticSize * length,
     _encode(buffer, value) {
       for (let i = 0; i < value.length; i++) {
@@ -27,8 +28,9 @@ export function sizedArray<L extends number, T>($el: Codec<T>, length: L) {
   });
 }
 
-export function array<T>($el: Codec<T>) {
-  return createCodec<T[]>({
+export function array<T>($el: Codec<T>): Codec<T[]> {
+  return createCodec({
+    _metadata: [array, $el],
     _staticSize: compact._staticSize,
     _encode(buffer, value) {
       compact._encode(buffer, value.length);
@@ -51,7 +53,8 @@ export function array<T>($el: Codec<T>) {
   });
 }
 
-export const uint8array = createCodec<Uint8Array>({
+export const uint8array: Codec<Uint8Array> = createCodec({
+  _metadata: null,
   _staticSize: compact._staticSize,
   _encode(buffer, value) {
     compact._encode(buffer, value.length);
@@ -65,8 +68,9 @@ export const uint8array = createCodec<Uint8Array>({
   },
 });
 
-export function sizedUint8array(length: number) {
-  return createCodec<Uint8Array>({
+export function sizedUint8array(length: number): Codec<Uint8Array> {
+  return createCodec({
+    _metadata: [sizedUint8array, length],
     // We could set `_staticSize` to `length`, but in this case it will usually
     // more efficient to insert the array dynamically, rather than manually copy
     // the bytes.

--- a/bool/codec.ts
+++ b/bool/codec.ts
@@ -1,6 +1,7 @@
-import { createCodec } from "../common.ts";
+import { Codec, createCodec } from "../common.ts";
 
-export const bool = createCodec<boolean>({
+export const bool: Codec<boolean> = createCodec({
+  _metadata: null,
   _staticSize: 1,
   _encode(buffer, value) {
     buffer.array[buffer.index++] = +value;

--- a/common.test.ts
+++ b/common.test.ts
@@ -1,0 +1,15 @@
+import { assertEquals } from "https://deno.land/std@0.139.0/testing/asserts.ts";
+import * as $ from "./mod.ts";
+import { assertThrowsSnapshot } from "./test-util.ts";
+
+Deno.test("CodecVisitor", async (t) => {
+  const visitor = new $.CodecVisitor<string>();
+  visitor
+    .add($.u8, () => "$.u8")
+    .add($.int, (_, signed, size) => `$.int(${signed}, ${size})`)
+    .add($.array, (_, $el) => `$.array(${visitor.visit($el)})`);
+
+  assertEquals(visitor.visit($.array($.array($.u8))), "$.array($.array($.u8))");
+  assertEquals(visitor.visit($.array($.u128)), "$.array($.int(false, 128))");
+  await assertThrowsSnapshot(t, () => visitor.visit($.str));
+});

--- a/common.ts
+++ b/common.ts
@@ -10,14 +10,21 @@ export interface Codec<T> {
   _encode: (buffer: EncodeBuffer, value: T) => void;
   /** [implementation] Decodes the value from the supplied buffer */
   _decode: (buffer: DecodeBuffer) => T;
+
+  _metadata?: [Function, ...unknown[]];
 }
 
-export function createCodec<T>(codec: Pick<Codec<T>, "_staticSize" | "_encode" | "_decode">): Codec<T> {
-  const { _staticSize, _encode, _decode } = codec;
+export function createCodec<T, A extends unknown[]>(
+  _codec: Pick<Codec<T>, "_encode" | "_decode" | "_staticSize"> & {
+    _metadata: [(...args: A) => Codec<T>, ...A] | null;
+  },
+): Codec<T> {
+  const { _staticSize, _encode, _decode, _metadata } = _codec;
   return {
     _staticSize,
     _encode,
     _decode,
+    ..._metadata && { _metadata },
     encode(value) {
       const buf = new EncodeBuffer(_staticSize);
       _encode(buf, value);

--- a/common.ts
+++ b/common.ts
@@ -11,11 +11,19 @@ export interface Codec<T> {
   /** [implementation] Decodes the value from the supplied buffer */
   _decode: (buffer: DecodeBuffer) => T;
 
+  /**
+   * If present, a factory function and the corresponding arguments.
+   * `undefined` indicates that this codec is atomic (e.g. `$.str`).
+   */
   _metadata?: [Function, ...unknown[]];
 }
 
 export function createCodec<T, A extends unknown[]>(
   _codec: Pick<Codec<T>, "_encode" | "_decode" | "_staticSize"> & {
+    /**
+     * If non-null, the function calling `createCodec` and the corresponding arguments.
+     * `null` indicates that this codec is atomic (e.g. `$.str`).
+     */
     _metadata: [(...args: A) => Codec<T>, ...A] | null;
   },
 ): Codec<T> {

--- a/common.ts
+++ b/common.ts
@@ -119,3 +119,56 @@ export class DecodeBuffer {
 
 export type Expand<T> = T extends T ? { [K in keyof T]: T[K] } : never;
 export type U2I<U> = (U extends U ? (u: U) => 0 : never) extends (i: infer I) => 0 ? Extract<I, U> : never;
+
+export class CodecVisitor<R> {
+  #fallback?: <T>(codec: Codec<T>) => R;
+  #visitors = new Map<Codec<any> | Function, (codec: Codec<any>, ...args: any[]) => R>();
+
+  constructor() {}
+
+  add<T, A extends unknown[]>(codec: (...args: A) => Codec<T>, fn: (codec: Codec<T>, ...args: A) => R): this;
+  add<T>(codec: Codec<T>, fn: (codec: Codec<T>) => R): this;
+  add(codec: Codec<any> | Function, fn: (codec: Codec<any>, ...args: any[]) => R): this {
+    if (this.#visitors.has(codec)) {
+      throw new Error("Duplicate visitor");
+    }
+    this.#visitors.set(codec, fn);
+    return this;
+  }
+
+  fallback(fn: <T>(codec: Codec<T>) => R): this {
+    if (this.#fallback) {
+      throw new Error("Duplicate fallback");
+    }
+    this.#fallback = fn;
+    return this;
+  }
+
+  /**
+   * Once Deno releases with TS 4.7, this can be used like so:
+   * ```ts
+   * visitor.generic((visitor) => <T>() =>
+   *   visitor.add($.array<T>, (codec, $el) => {
+   *     ...
+   *   })
+   * )
+   * ```
+   */
+  generic(fn: (visitor: this) => () => void): this {
+    fn(this)();
+    return this;
+  }
+
+  visit<T>(codec: Codec<T>): R {
+    const visitor = this.#visitors.get(codec);
+    if (visitor) return visitor(codec);
+    if (codec._metadata) {
+      const visitor = this.#visitors.get(codec._metadata[0]);
+      if (visitor) return visitor(codec, ...codec._metadata.slice(1));
+    }
+    if (this.#fallback) {
+      return this.#fallback(codec);
+    }
+    throw new Error("Unrecognized codec");
+  }
+}

--- a/compact/codec.ts
+++ b/compact/codec.ts
@@ -5,7 +5,8 @@ const MAX_U8 = 2 ** (8 - 2) - 1;
 const MAX_U16 = 2 ** (16 - 2) - 1;
 const MAX_U32 = 2 ** (32 - 2) - 1;
 
-export const compact = createCodec<number | bigint>({
+export const compact: Codec<number | bigint> = createCodec({
+  _metadata: null,
   _staticSize: 4,
   _encode(buffer, value) {
     if (value <= MAX_U8) {

--- a/constantPattern/codec.ts
+++ b/constantPattern/codec.ts
@@ -4,7 +4,8 @@ export function constantPattern<T>(value: T, codec: Pick<Codec<T>, "encode">): C
 export function constantPattern<T>(value: T, pattern: Uint8Array): Codec<T>;
 export function constantPattern<T>(value: T, c: Pick<Codec<T>, "encode"> | Uint8Array): Codec<T> {
   const pattern = c instanceof Uint8Array ? c : c.encode(value);
-  return createCodec<T>({
+  return createCodec({
+    _metadata: [constantPattern as never, value, pattern],
     // We could set `_staticSize` to `pattern.length`, but in this case it will
     // usually more efficient to insert `pattern` dynamically, rather than
     // manually copy the bytes.

--- a/deferred/codec.ts
+++ b/deferred/codec.ts
@@ -3,6 +3,7 @@ import { Codec } from "../common.ts";
 export function deferred<T>(getCodec: () => Codec<T>): Codec<T> {
   let $codec: Codec<T>;
   return {
+    _metadata: [deferred, getCodec],
     _staticSize: 0,
     _encode(buffer, value) {
       $codec ??= getCodec();

--- a/dummy/codec.ts
+++ b/dummy/codec.ts
@@ -1,12 +1,13 @@
-import { createCodec } from "../common.ts";
+import { Codec, createCodec } from "../common.ts";
 
 /**
  * `Dummy`'s decoder returns a hard-coded JS value and DOES NOT encode or decode from any bytes.
  * @param value The native value corresponding to the generically-supplied codec
  * @returns A dummy codec with the patched signature of `E`
  */
-export function dummy<T>(value: T) {
+export function dummy<T>(value: T): Codec<T> {
   return createCodec({
+    _metadata: [dummy, value],
     _staticSize: 0,
     _encode() {},
     _decode() {

--- a/instance/codec.ts
+++ b/instance/codec.ts
@@ -18,10 +18,11 @@ export function instance<
 >(
   ctor: Ctor,
   ...fields: Fields
-) {
+): Codec<InstanceType<Ctor>> {
   const $object = object(...fields);
-  return createCodec<InstanceType<Ctor>>({
+  return createCodec({
     ...$object as Codec<any>,
+    _metadata: [instance, ctor, ...fields] as any,
     _decode(buffer) {
       const arr = Array(fields.length);
       for (let i = 0; i < arr.length; i++) {

--- a/int/codec.ts
+++ b/int/codec.ts
@@ -91,7 +91,8 @@ export const i256 = _256(true);
 export function int(signed: boolean, size: 8 | 16 | 32): Codec<number>;
 export function int(signed: boolean, size: 64 | 128 | 256): Codec<bigint>;
 export function int(signed: boolean, size: 8 | 16 | 32 | 64 | 128 | 256): Codec<number> | Codec<bigint>;
-export function int(signed: boolean, size: 8 | 16 | 32 | 64 | 128 | 256): Codec<number> | Codec<bigint> {
+export function int(signed: boolean, size: 8 | 16 | 32 | 64 | 128 | 256): Codec<number | bigint>;
+export function int(signed: boolean, size: 8 | 16 | 32 | 64 | 128 | 256): Codec<any> {
   const key = `${signed ? "i" : "u"}${size}` as const;
   return {
     u8,

--- a/int/codec.ts
+++ b/int/codec.ts
@@ -1,6 +1,7 @@
 import { Codec, createCodec } from "../common.ts";
 
-export const u8 = createCodec<number>({
+export const u8: Codec<number> = createCodec({
+  _metadata: [int, false, 8] as any,
   _staticSize: 1,
   _encode(buffer, value) {
     buffer.array[buffer.index++] = value;
@@ -17,6 +18,7 @@ function _int<K extends NumMethodKeys>(size: number, key: K): Codec<NumMethodVal
   const getMethod = DataView.prototype["get" + key as never] as any;
   const setMethod = DataView.prototype["set" + key as never] as any;
   return createCodec({
+    _metadata: [int, key.includes("Int"), size * 8] as any,
     _staticSize: size,
     _encode(buffer, value) {
       setMethod.call(buffer.view, buffer.index, value, true);
@@ -38,9 +40,10 @@ export const i32 = _int(4, "Int32");
 export const u64 = _int(8, "BigUint64");
 export const i64 = _int(8, "BigInt64");
 
-const _128 = (signed: boolean) => {
+const _128 = (signed: boolean): Codec<bigint> => {
   const getMethod = DataView.prototype[signed ? "getBigInt64" : "getBigUint64"];
-  return createCodec<bigint>({
+  return createCodec({
+    _metadata: [int, signed, 128] as any,
     _staticSize: 16,
     _encode(buffer, value) {
       buffer.view.setBigInt64(buffer.index, value, true);
@@ -59,9 +62,10 @@ const _128 = (signed: boolean) => {
 export const u128 = _128(false);
 export const i128 = _128(true);
 
-const _256 = (signed: boolean) => {
+const _256 = (signed: boolean): Codec<bigint> => {
   const getMethod = DataView.prototype[signed ? "getBigInt64" : "getBigUint64"];
-  return createCodec<bigint>({
+  return createCodec({
+    _metadata: [int, signed, 256] as any,
     _staticSize: 32,
     _encode(buffer, value) {
       buffer.view.setBigInt64(buffer.index, value, true);
@@ -83,3 +87,24 @@ const _256 = (signed: boolean) => {
 
 export const u256 = _256(false);
 export const i256 = _256(true);
+
+export function int(signed: boolean, size: 8 | 16 | 32): Codec<number>;
+export function int(signed: boolean, size: 64 | 128 | 256): Codec<bigint>;
+export function int(signed: boolean, size: 8 | 16 | 32 | 64 | 128 | 256): Codec<number> | Codec<bigint>;
+export function int(signed: boolean, size: 8 | 16 | 32 | 64 | 128 | 256): Codec<number> | Codec<bigint> {
+  const key = `${signed ? "i" : "u"}${size}` as const;
+  return {
+    u8,
+    i8,
+    u16,
+    i16,
+    u32,
+    i32,
+    u64,
+    i64,
+    u128,
+    i128,
+    u256,
+    i256,
+  }[key];
+}

--- a/iterable/codec.ts
+++ b/iterable/codec.ts
@@ -8,8 +8,9 @@ export function iterable<T, I extends Iterable<T>>(
     calcLength: (iterable: I) => number;
     rehydrate: (iterable: Iterable<T>) => I;
   },
-) {
-  return createCodec<I>({
+): Codec<I> {
+  return createCodec({
+    _metadata: [iterable, { $el, calcLength, rehydrate }],
     _staticSize: compact._staticSize,
     _encode(buffer, value) {
       const length = calcLength(value);

--- a/never/codec.ts
+++ b/never/codec.ts
@@ -1,6 +1,7 @@
-import { createCodec } from "../common.ts";
+import { Codec, createCodec } from "../common.ts";
 
-export const never = createCodec<never>({
+export const never: Codec<never> = createCodec({
+  _metadata: null,
   _staticSize: 0,
   _encode() {
     throw new Error("Cannot encode $.never");

--- a/object/codec.ts
+++ b/object/codec.ts
@@ -21,8 +21,9 @@ export function object<
   Fields extends Field<EntryKey, EntryValueCodec>[],
   EntryKey extends PropertyKey,
   EntryValueCodec extends Codec<any>,
->(...fields: Fields) {
-  return createCodec<NativeObject<Fields>>({
+>(...fields: Fields): Codec<NativeObject<Fields>> {
+  return createCodec({
+    _metadata: [object, ...fields],
     _staticSize: fields.map((x) => x[1]._staticSize).reduce((a, b) => a + b, 0),
     _encode(buffer, value) {
       fields.forEach(([key, fieldEncoder]) => {

--- a/option/codec.ts
+++ b/option/codec.ts
@@ -2,6 +2,7 @@ import { Codec, createCodec } from "../common.ts";
 
 export function option<Some>($some: Codec<Some>): Codec<Some | undefined> {
   return createCodec({
+    _metadata: [option, $some],
     _staticSize: 1 + $some._staticSize,
     _encode(buffer, value) {
       buffer.array[buffer.index++] = +(value !== undefined);

--- a/option/optionBool/codec.ts
+++ b/option/optionBool/codec.ts
@@ -1,6 +1,7 @@
-import { createCodec } from "../../common.ts";
+import { Codec, createCodec } from "../../common.ts";
 
-export const optionBool = createCodec<boolean | undefined>({
+export const optionBool: Codec<boolean | undefined> = createCodec({
+  _metadata: null,
   _staticSize: 1,
   _encode(buffer, value) {
     buffer.array[buffer.index++] = value === undefined ? 0 : 1 + +!value;

--- a/result/codec.ts
+++ b/result/codec.ts
@@ -5,11 +5,16 @@ export function result<Ok, Err extends Error>(
   $ok: Codec<Ok>,
   $err: Codec<Err>,
 ) {
-  return union(
-    (value) => {
-      return value instanceof Error ? 1 : 0;
+  return Object.assign(
+    union(
+      (value) => {
+        return value instanceof Error ? 1 : 0;
+      },
+      $ok,
+      $err,
+    ),
+    {
+      _metadata: [result, $ok, $err],
     },
-    $ok,
-    $err,
   );
 }

--- a/spread/codec.ts
+++ b/spread/codec.ts
@@ -1,7 +1,8 @@
 import { Codec, createCodec } from "../common.ts";
 
-export function spread<A, B>($a: Codec<A>, $b: Codec<B>) {
-  return createCodec<A & B>({
+export function spread<A, B>($a: Codec<A>, $b: Codec<B>): Codec<A & B> {
+  return createCodec({
+    _metadata: [spread, $a, $b],
     _staticSize: $a._staticSize + $b._staticSize,
     _encode(buffer, value) {
       $a._encode(buffer, value);

--- a/str/codec.ts
+++ b/str/codec.ts
@@ -1,7 +1,8 @@
-import { createCodec } from "../common.ts";
+import { Codec, createCodec } from "../common.ts";
 import { compact } from "../compact/codec.ts";
 
-export const str = createCodec<string>({
+export const str: Codec<string> = createCodec({
+  _metadata: null,
   _staticSize: compact._staticSize,
   _encode(buffer, value) {
     const array = new TextEncoder().encode(value);

--- a/transform/codec.ts
+++ b/transform/codec.ts
@@ -1,7 +1,8 @@
 import { Codec, createCodec } from "../common.ts";
 
-export function transform<T, U>($base: Codec<T>, encode: (value: U) => T, decode: (value: T) => U) {
-  return createCodec<U>({
+export function transform<T, U>($base: Codec<T>, encode: (value: U) => T, decode: (value: T) => U): Codec<U> {
+  return createCodec({
+    _metadata: [transform, $base, encode, decode],
     _staticSize: $base._staticSize,
     _encode(buffer, value) {
       $base._encode(buffer, encode(value));

--- a/tuple/codec.ts
+++ b/tuple/codec.ts
@@ -4,8 +4,9 @@ export type NativeTuple<ElCodecs extends Codec<any>[]> = {
   [I in keyof ElCodecs]: ElCodecs[I] extends Codec<infer T> ? T : never;
 };
 
-export function tuple<T extends Codec<any>[]>(...codecs: [...T]) {
-  return createCodec<NativeTuple<T>>({
+export function tuple<T extends Codec<any>[]>(...codecs: [...T]): Codec<NativeTuple<T>> {
+  return createCodec<NativeTuple<T>, [...T]>({
+    _metadata: [tuple, ...codecs],
     _staticSize: codecs.map((x) => x._staticSize).reduce((a, b) => a + b, 0),
     _encode(buffer, value) {
       for (let i = 0; i < codecs.length; i++) {

--- a/union/codec.ts
+++ b/union/codec.ts
@@ -5,8 +5,9 @@ export type NativeUnion<MemberCodecs extends Codec<any>[]> = Native<MemberCodecs
 export function union<Members extends Codec<any>[]>(
   discriminate: (value: NativeUnion<Members>) => number,
   ...$members: [...Members]
-) {
-  return createCodec<NativeUnion<Members>>({
+): Codec<NativeUnion<Members>> {
+  return createCodec({
+    _metadata: [union, discriminate, ...$members],
     _staticSize: 1 + Math.max(...$members.map((x) => x._staticSize)),
     _encode(buffer, value) {
       const discriminant = discriminate(value);

--- a/union/key/codec.ts
+++ b/union/key/codec.ts
@@ -1,13 +1,14 @@
-import { createCodec } from "../../common.ts";
+import { Codec, createCodec } from "../../common.ts";
 
-export function keyLiteralUnion<Member extends PropertyKey>(...members: Member[]) {
+export function keyLiteralUnion<Member extends PropertyKey>(...members: Member[]): Codec<Member> {
   const discriminantByKey = members.reduce<Partial<Record<Member, number>>>((acc, cur, i) => {
     return {
       ...acc,
       [cur]: i,
     };
   }, {}) as Partial<Record<Member, number>>;
-  return createCodec<Member>({
+  return createCodec({
+    _metadata: [keyLiteralUnion, ...members],
     _staticSize: 1,
     _encode(buffer, value) {
       const discriminant = discriminantByKey[value]!;

--- a/union/tagged/codec.ts
+++ b/union/tagged/codec.ts
@@ -35,17 +35,22 @@ export function taggedUnion<
   tagKey: TagKey,
   ...members: Members
 ) {
-  return union<Codec<NativeTaggedUnionMembers<TagKey, Members>>[]>(
-    (value) => {
-      return members.findIndex((member) => {
-        return member[0] === value[tagKey];
-      });
+  return Object.assign(
+    union<Codec<NativeTaggedUnionMembers<TagKey, Members>>[]>(
+      (value) => {
+        return members.findIndex((member) => {
+          return member[0] === value[tagKey];
+        });
+      },
+      ...members.map(([memberTag, ...fields]) => {
+        return object(
+          ["_tag", dummy(memberTag)],
+          ...fields || [],
+        ) as NativeTaggedUnionMembers<TagKey, Members>;
+      }),
+    ),
+    {
+      metadata: [taggedUnion, tagKey, ...members],
     },
-    ...members.map(([memberTag, ...fields]) => {
-      return object(
-        ["_tag", dummy(memberTag)],
-        ...fields || [],
-      ) as NativeTaggedUnionMembers<TagKey, Members>;
-    }),
   );
 }


### PR DESCRIPTION
Fixes #61 
- Adds an `_metadata` field to `Codec`, which, if present, is `[factory, ...args]`
- Adds an `_metadata` field to `createCodec`'s argument, which, unlike that of `Codec<T>`, much be explicitly specified to be `null` if absent
- Adds a utility builder-pattern class `CodecVisitor` for traversing the metadata type-safely