### PR TITLE
chore: explicitly specify `dprint` as formatter for typescript in `.vscode/settings.json`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,9 @@
   "[yaml]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "[typescript]": {
+    "editor.defaultFormatter": "dprint.dprint"
+  },
   "deno.config": "./deno.jsonc",
   "deno.enable": true,
   "deno.importMap": "./import_map.json",


### PR DESCRIPTION
This makes it work even if one has a user override for typescript formatter.

Not strictly necessary, but will make my life a lot easier.