### PR TITLE
chore: get rid of non-test usage of `Deno` global

### DIFF
--- a/_tasks/build_npm_pkg.ts
+++ b/_tasks/build_npm_pkg.ts
@@ -17,7 +17,9 @@ await build({
     repository: "github:paritytech/parity-scale-codec-ts",
   },
   shims: {
-    deno: true,
+    deno: {
+      test: true,
+    },
   },
   compilerOptions: {
     sourceMap: true,

--- a/constantPattern/codec.ts
+++ b/constantPattern/codec.ts
@@ -12,7 +12,7 @@ export function constantPattern<T>(value: T, c: Pick<Codec<T>, "encode"> | Uint8
     _staticSize: 0,
     _encode(buffer, got) {
       if (got !== value) {
-        throw new Error(`Invalid value; expected ${Deno.inspect(value)}, got ${Deno.inspect(got)}`);
+        throw new Error(`Invalid value; expected ${value}, got ${got}`);
       }
       buffer.insertArray(pattern);
     },


### PR DESCRIPTION
Solves issues for dependents who can't properly shake downstream usage of `fs` and other such env-specific mods.