### PR TITLE
feat: expand compact

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -135,7 +135,12 @@ $.u256; // Codec<bigint>
 $.i256; // Codec<bigint>
 
 // https://docs.substrate.io/v3/advanced/scale-codec/#compactgeneral-integers
-$.compact; // Codec<number | bigint>
+$.compactU8; // Codec<number>
+$.compactU16; // Codec<number>
+$.compactU32; // Codec<number>
+$.compactU64; // Codec<bigint>
+$.compactU128; // Codec<bigint>
+$.compactU256; // Codec<bigint>
 
 $.str; // Codec<string>
 

--- a/array/bench.ts
+++ b/array/bench.ts
@@ -7,12 +7,12 @@ function arr<T>(length: number, el: (i: number) => T): T[] {
 
 benchCodec("bool[0]", $.array($.bool), []);
 benchCodec("u128[0]", $.array($.u128), []);
-benchCodec("compact[0]", $.array($.compact), []);
+benchCodec("compactU256[0]", $.array($.compactU256), []);
 
 benchCodec("bool[128]", $.array($.bool), arr(128, (i) => i % 2 === 0));
 benchCodec("u128[128]", $.array($.u128), arr(128, (i) => 2n ** BigInt(i % 100) + BigInt(i)));
-benchCodec("compact[128]", $.array($.compact), arr(128, (i) => 2n ** BigInt(i % 100) + BigInt(i)));
+benchCodec("compactU256[128]", $.array($.compactU256), arr(128, (i) => 2n ** BigInt(i % 100) + BigInt(i)));
 
 benchCodec("bool[16384]", $.array($.bool), arr(16384, (i) => i % 2 === 0));
 benchCodec("u128[16384]", $.array($.u128), arr(16384, (i) => 2n ** BigInt(i % 100) + BigInt(i)));
-benchCodec("compact[16384]", $.array($.compact), arr(16384, (i) => 2n ** BigInt(i % 100) + BigInt(i)));
+benchCodec("compactU256[16384]", $.array($.compactU256), arr(16384, (i) => 2n ** BigInt(i % 100) + BigInt(i)));

--- a/array/codec.ts
+++ b/array/codec.ts
@@ -1,5 +1,5 @@
 import { Codec, createCodec } from "../common.ts";
-import { compact } from "../compact/codec.ts";
+import { compactU32 } from "../compact/codec.ts";
 
 type ArrayOfLength<
   T,
@@ -33,9 +33,9 @@ export function array<T>($el: Codec<T>): Codec<T[]> {
   return createCodec({
     name: "array",
     _metadata: [array, $el],
-    _staticSize: compact._staticSize,
+    _staticSize: compactU32._staticSize,
     _encode(buffer, value) {
-      compact._encode(buffer, value.length);
+      compactU32._encode(buffer, value.length);
       if (value.length) {
         buffer.pushAlloc(value.length * $el._staticSize);
         for (let i = 0; i < value.length; i++) {
@@ -45,7 +45,7 @@ export function array<T>($el: Codec<T>): Codec<T[]> {
       }
     },
     _decode(buffer) {
-      const length = Number(compact._decode(buffer));
+      const length = compactU32._decode(buffer);
       const value: T[] = Array(length);
       for (let i = 0; i < value.length; i++) {
         value[i] = $el._decode(buffer);
@@ -58,13 +58,13 @@ export function array<T>($el: Codec<T>): Codec<T[]> {
 export const uint8array: Codec<Uint8Array> = createCodec({
   name: "uint8array",
   _metadata: null,
-  _staticSize: compact._staticSize,
+  _staticSize: compactU32._staticSize,
   _encode(buffer, value) {
-    compact._encode(buffer, value.length);
+    compactU32._encode(buffer, value.length);
     buffer.insertArray(value); // the contents of this will eventually be cloned by buffer
   },
   _decode(buffer) {
-    const length = Number(compact._decode(buffer));
+    const length = compactU32._decode(buffer);
     const value = buffer.array.subarray(buffer.index, buffer.index + length);
     buffer.index += length;
     return value;

--- a/bitSequence/codec.ts
+++ b/bitSequence/codec.ts
@@ -1,5 +1,5 @@
 import { Codec, createCodec } from "../common.ts";
-import { nCompact } from "../compact/codec.ts";
+import { compactU32 } from "../compact/codec.ts";
 
 export class BitSequence {
   readonly data;
@@ -66,13 +66,13 @@ Object.setPrototypeOf(
 export const bitSequence: Codec<BitSequence> = createCodec({
   name: "bitSequence",
   _metadata: null,
-  _staticSize: nCompact._staticSize,
+  _staticSize: compactU32._staticSize,
   _encode(buffer, value) {
-    nCompact._encode(buffer, value.length);
+    compactU32._encode(buffer, value.length);
     buffer.insertArray(value.data);
   },
   _decode(buffer) {
-    const length = nCompact._decode(buffer);
+    const length = compactU32._decode(buffer);
     const byteLength = Math.ceil(length / 8);
     return new BitSequence(length, buffer.array.subarray(buffer.index, buffer.index += byteLength));
   },

--- a/compact/__snapshots__/test.ts.snap
+++ b/compact/__snapshots__/test.ts.snap
@@ -1,20 +1,36 @@
 export const snapshot = {};
 
-snapshot[`compact 0 1`] = `00`;
+snapshot[`compactU32 0 1`] = `00`;
 
-snapshot[`compact 255 1`] = `
+snapshot[`compactU32 1 1`] = `04`;
+
+snapshot[`compactU32 63 1`] = `fc`;
+
+snapshot[`compactU32 255 1`] = `
 fd
 03
 `;
 
-snapshot[`compact 65535 1`] = `
+snapshot[`compactU32 16383 1`] = `
+fd
+ff
+`;
+
+snapshot[`compactU32 65535 1`] = `
 fe
 ff
 03
 00
 `;
 
-snapshot[`compact 4294967295 1`] = `
+snapshot[`compactU32 1073741823 1`] = `
+fe
+ff
+ff
+ff
+`;
+
+snapshot[`compactU32 4294967295 1`] = `
 03
 ff
 ff
@@ -22,7 +38,32 @@ ff
 ff
 `;
 
-snapshot[`compact 18446744073709551615n 1`] = `
+snapshot[`compactU256 0n 1`] = `00`;
+
+snapshot[`compactU256 63n 1`] = `fc`;
+
+snapshot[`compactU256 16383n 1`] = `
+fd
+ff
+`;
+
+snapshot[`compactU256 1073741823n 1`] = `
+fe
+ff
+ff
+ff
+`;
+
+snapshot[`compactU256 1099511627775n 1`] = `
+07
+ff
+ff
+ff
+ff
+ff
+`;
+
+snapshot[`compactU256 18446744073709551615n 1`] = `
 13
 ff
 ff
@@ -34,8 +75,135 @@ ff
 ff
 `;
 
-snapshot[`compact 340282366920938463463374607431768211455n 1`] = `
+snapshot[`compactU256 340282366920938463463374607431768211455n 1`] = `
 33
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+`;
+
+snapshot[`compactU256 340282366920938463463374607431768211455n 2`] = `
+33
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+`;
+
+snapshot[`compactU256 115792089237316195423570985008687907853269984665640564039457584007913129639935n 1`] = `
+73
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+`;
+
+snapshot[`compactU256 224945689727159819140526925384299092943484855915095831655037778630591879033574393515952034305194542857496045531676044756160413302774714984450425759043258192756735n 1`] = `
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
+ff
 ff
 ff
 ff

--- a/compact/bench.ts
+++ b/compact/bench.ts
@@ -1,8 +1,15 @@
 import { benchCodec } from "../test-util.ts";
 import * as $ from "./codec.ts";
 
-benchCodec("compact (u8)", $.compact, 2 ** (8 - 2) - 1);
-benchCodec("compact (u16)", $.compact, 2 ** (16 - 2) - 1);
-benchCodec("compact (u32)", $.compact, 2 ** (32 - 2) - 1);
-benchCodec("compact (b64)", $.compact, 2n ** 64n - 1n);
-benchCodec("compact (b128)", $.compact, 2n ** 128n - 1n);
+benchCodec("compactU32 (6)", $.compactU32, 2 ** 6 - 1);
+benchCodec("compactU32 (14)", $.compactU32, 2 ** 14 - 1);
+benchCodec("compactU32 (30)", $.compactU32, 2 ** 30 - 1);
+benchCodec("compactU32 (32)", $.compactU32, 2 ** 32 - 1);
+
+benchCodec("compactU256 (6)", $.compactU256, 2n ** 6n - 1n);
+benchCodec("compactU256 (14)", $.compactU256, 2n ** 14n - 1n);
+benchCodec("compactU256 (30)", $.compactU256, 2n ** 30n - 1n);
+benchCodec("compactU256 (32)", $.compactU256, 2n ** 32n - 1n);
+benchCodec("compactU256 (64)", $.compactU256, 2n ** 64n - 1n);
+benchCodec("compactU256 (128)", $.compactU256, 2n ** 128n - 1n);
+benchCodec("compactU256 (256)", $.compactU256, 2n ** 256n - 1n);

--- a/compact/codec.ts
+++ b/compact/codec.ts
@@ -1,82 +1,85 @@
 import { Codec, createCodec } from "../common.ts";
-import { u16, u32, u8 } from "../int/codec.ts";
+import { u16, u32 } from "../int/codec.ts";
 
-const MAX_U8 = 2 ** (8 - 2) - 1;
-const MAX_U16 = 2 ** (16 - 2) - 1;
-const MAX_U32 = 2 ** (32 - 2) - 1;
+const MAX_U8 = 0b00111111;
+const MAX_U16 = 0b00111111_11111111;
+const MAX_U32 = 0b00111111_11111111_11111111_11111111;
 
-export const compact: Codec<number | bigint> = createCodec({
-  name: "compact",
+const compactNumber: Codec<number> = createCodec({
+  name: "compactNumber",
   _metadata: null,
-  _staticSize: 4,
+  _staticSize: 5,
   _encode(buffer, value) {
     if (value <= MAX_U8) {
-      u8._encode(buffer, Number(value) << 2);
+      buffer.array[buffer.index++] = value << 2;
+    } else if (value <= MAX_U16) {
+      u16._encode(buffer, (value << 2) | 0b01);
+    } else if (value <= MAX_U32) {
+      u32._encode(buffer, (value << 2) | 0b10);
+    } else {
+      buffer.array[buffer.index++] = 0b11;
+      u32._encode(buffer, value);
+    }
+  },
+  _decode(buffer) {
+    switch (buffer.array[buffer.index]! & 0b11) {
+      case 0:
+        return buffer.array[buffer.index++]! >> 2;
+      case 1:
+        return u16._decode(buffer) >> 2;
+      case 2:
+        return (u32._decode(buffer) - 2) / 4;
+      default:
+        if (buffer.array[buffer.index++]! !== 3) throw new Error("Out of range for U32");
+        return u32._decode(buffer);
+    }
+  },
+});
+
+export const compactU8 = compactNumber;
+export const compactU16 = compactNumber;
+export const compactU32 = compactNumber;
+
+const compactBigInt: Codec<bigint> = createCodec({
+  name: "compactBigInt",
+  _metadata: null,
+  _staticSize: 5,
+  _encode(buffer, value) {
+    if (value <= 0xff_ff_ff_ff) {
+      compactNumber._encode(buffer, Number(value));
       return;
     }
-    if (value <= MAX_U16) {
-      u16._encode(buffer, Number((BigInt(value) << 2n) + 0b01n));
-      return;
-    }
-    if (value <= MAX_U32) {
-      u32._encode(buffer, Number((BigInt(value) << 2n) + 0b10n));
-      return;
-    }
-    let bytesLength = 0;
-    let _value = BigInt(value);
+    let extraBytes = 0;
+    let _value = value >> 32n;
     while (_value > 0n) {
       _value >>= 8n;
-      bytesLength++;
+      extraBytes++;
     }
-    _value = BigInt(value);
-    buffer.array[buffer.index++] = ((bytesLength - 4) << 2) + 0b11;
-    for (let i = 0; i < bytesLength; i++) {
-      if (i === 3) {
-        buffer.pushAlloc(bytesLength - 3);
-      }
+    buffer.array[buffer.index++] = (extraBytes << 2) | 0b11;
+    u32._encode(buffer, Number(value & 0xff_ff_ff_ffn));
+    _value = value >> 32n;
+    buffer.pushAlloc(extraBytes);
+    for (let i = 0; i < extraBytes; i++) {
       buffer.array[buffer.index++] = Number(_value & 0xffn);
       _value >>= 8n;
     }
     buffer.popAlloc();
   },
   _decode(buffer) {
-    const b = u8._decode(buffer);
-    switch ((b & 3) as 0 | 1 | 2 | 3) {
-      case 0: {
-        return b >> 2;
-      }
-      case 1: {
-        return (b >> 2) + u8._decode(buffer) * 2 ** 6;
-      }
-      case 2: {
-        return (b >> 2) + u8._decode(buffer) * 2 ** 6 + u8._decode(buffer) * 2 ** 14
-          + u8._decode(buffer) * 2 ** 22;
-      }
-      case 3: {
-        const decodedU32 = u32._decode(buffer);
-        let len = b >> 2;
-        switch (len) {
-          case 0: {
-            return decodedU32;
-          }
-          case 1: {
-            return decodedU32 + u8._decode(buffer) * 2 ** 32;
-          }
-          case 2: {
-            return decodedU32 + u8._decode(buffer) * 2 ** 32 + u8._decode(buffer) * 2 ** 40;
-          }
-        }
-        let decodedU32AsBigint = BigInt(decodedU32);
-        let base = 32n;
-        while (len--) {
-          decodedU32AsBigint += BigInt(u8._decode(buffer)) << base;
-          base += 8n;
-        }
-        return decodedU32AsBigint;
-      }
+    const b = buffer.array[buffer.index]!;
+    if ((b & 0b11) < 3 || b === 3) {
+      return BigInt(compactNumber._decode(buffer));
     }
+    const extraBytes = b >> 2;
+    buffer.index++;
+    let value = BigInt(u32._decode(buffer));
+    for (let i = 0; i < extraBytes; i++) {
+      value |= BigInt(buffer.array[buffer.index++]!) << BigInt(32 + i * 8);
+    }
+    return value;
   },
 });
 
-// TODO: finesse
-export const nCompact = compact as any as Codec<number>;
+export const compactU64 = compactBigInt;
+export const compactU128 = compactBigInt;
+export const compactU256 = compactBigInt;

--- a/compact/fixtures.rs
+++ b/compact/fixtures.rs
@@ -1,11 +1,29 @@
 #[allow(unused_imports)]
 use parity_scale_codec::Compact;
 
+macro_rules! n {
+  ($x:literal $t:ty) => {
+    Compact::<$t>((1 << ($x - 1)) - 1 + (1 << ($x - 1)))
+  };
+}
+
 crate::fixtures!(
   Compact(0u8),
-  Compact(u8::MAX),
-  Compact(u16::MAX),
-  Compact(u32::MAX),
-  Compact(u64::MAX),
-  Compact(u128::MAX),
+  n!(1 u8),
+  n!(6 u8),
+  n!(8 u8),
+  n!(14 u16),
+  n!(16 u16),
+  n!(30 u32),
+  n!(32 u32),
+  Compact(0u128),
+  n!(6 u128),
+  n!(14 u128),
+  n!(30 u128),
+  n!(40 u128),
+  n!(64 u128),
+  n!(128 u128),
+  ((12 << 2) | 0b11u8, u64::MAX, u64::MAX),
+  ((28 << 2) | 0b11u8, u128::MAX, u128::MAX),
+  [u8::MAX; 68],
 );

--- a/compact/test.ts
+++ b/compact/test.ts
@@ -1,11 +1,5 @@
 import * as $ from "../mod.ts";
 import { testCodec } from "../test-util.ts";
 
-testCodec("compact", $.compact, [
-  0,
-  2 ** 8 - 1,
-  2 ** 16 - 1,
-  2 ** 32 - 1,
-  2n ** 64n - 1n,
-  2n ** 128n - 1n,
-]);
+testCodec("compactU32", $.compactU32, [0, 1, 6, 8, 14, 16, 30, 32].map((x) => (2 ** x) - 1));
+testCodec("compactU256", $.compactU256, [0, 6, 14, 30, 40, 64, 128, 128, 256, 536].map((x) => (1n << BigInt(x)) - 1n));

--- a/iterable/codec.ts
+++ b/iterable/codec.ts
@@ -1,5 +1,5 @@
 import { Codec, createCodec } from "../common.ts";
-import { compact } from "../compact/codec.ts";
+import { compactU32 } from "../compact/codec.ts";
 import { tuple } from "../mod.ts";
 
 export function iterable<T, I extends Iterable<T>>(
@@ -12,10 +12,10 @@ export function iterable<T, I extends Iterable<T>>(
   return createCodec({
     name: "iterable",
     _metadata: [iterable, { $el, calcLength, rehydrate }],
-    _staticSize: compact._staticSize,
+    _staticSize: compactU32._staticSize,
     _encode(buffer, value) {
       const length = calcLength(value);
-      compact._encode(buffer, length);
+      compactU32._encode(buffer, length);
       buffer.pushAlloc(length * $el._staticSize);
       let i = 0;
       for (const el of value) {
@@ -26,7 +26,7 @@ export function iterable<T, I extends Iterable<T>>(
       buffer.popAlloc();
     },
     _decode(buffer) {
-      const length = compact._decode(buffer);
+      const length = compactU32._decode(buffer);
       let done = false;
       const value = rehydrate(function*() {
         for (let i = 0; i < length; i++) {

--- a/promise/__snapshots__/test.ts.snap
+++ b/promise/__snapshots__/test.ts.snap
@@ -533,7 +533,7 @@ e6
 f3
 `;
 
-snapshot[`promise(array(promise(compact))) times13 1`] = `
+snapshot[`promise(array(promise(compactU32))) times13 1`] = `
 01
 04
 00

--- a/promise/test.ts
+++ b/promise/test.ts
@@ -13,7 +13,7 @@ testCodec("array(promise(u8))", $.array($.promise($.u8)), {
   times13: () => Array.from({ length: 256 }, (_, i) => prom(i * 13 % 256)),
 }, true);
 
-testCodec("promise(array(promise(compact)))", $.promise($.array($.promise($.compact))), {
+testCodec("promise(array(promise(compactU32)))", $.promise($.array($.promise($.compactU32))), {
   times13: () => Promise.resolve(Array.from({ length: 256 }, (_, i) => prom(i * 13 % 256))),
 }, true);
 

--- a/str/codec.ts
+++ b/str/codec.ts
@@ -1,18 +1,17 @@
 import { Codec, createCodec } from "../common.ts";
-import { compact } from "../compact/codec.ts";
+import { compactU32 } from "../compact/codec.ts";
 
 export const str: Codec<string> = createCodec({
   name: "str",
   _metadata: null,
-  _staticSize: compact._staticSize,
+  _staticSize: compactU32._staticSize,
   _encode(buffer, value) {
     const array = new TextEncoder().encode(value);
-    compact._encode(buffer, array.length);
+    compactU32._encode(buffer, array.length);
     buffer.insertArray(array);
   },
   _decode(buffer) {
-    // TODO: do we like this conversion? Safeguard.
-    const len = Number(compact._decode(buffer));
+    const len = compactU32._decode(buffer);
     if (buffer.array.length < buffer.index + len) {
       throw new Error("Attempting to `str`-decode beyond bounds of input bytes");
     }


### PR DESCRIPTION
Currently, we treat `compact` as a single type. However, in the rust implementation, `Compact` is a generic wrapper type, and types such as `Compact<u8>`, `Compact<u128>`, etc. all have their own codec implementations. Furthermore, `Compact<>` isn't used solely for numbers – I believe libraries can implement `Encode`/`Decode` for `Compact<TheirCustomType>`.

Thus, in this library, we should reflect that, by replacing `$.compact` with `$.compactU8`, `$.compactU128`, etc.

Because the encoding of compact is the same across all `u*` types, we only need distinct implementations for the `number`-sized `u*`s and the `bigint`-sized `u*`s. Thus, we define `compactNumber` and `compactBigInt`, and simply set `$.compactU8 = compactNumber`, `$.compactU128 = compactBigInt`, etc.

We expose `$.compactU*` rather than `compactNumber` and `compactBigInt` directly in order to better parallel the rust implementation, and to allow us to potentially add range checks to these codecs in the future.