### PR TITLE
fix: casing of `$.uint8Array` and `$.sizedUint8Array`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -156,9 +156,9 @@ $.array($.u8); // Codec<number[]>
 
 $.sizedArray($.u8, 2); // Codec<[number, number]>
 
-$.uint8array; // Codec<Uint8Array>
+$.uint8Array; // Codec<Uint8Array>
 
-$.sizedUint8array(12); // Codec<Uint8Array>
+$.sizedUint8Array(12); // Codec<Uint8Array>
 
 $.tuple($.bool, $.u8, $.str); // Codec<[boolean, number, string]>
 

--- a/array/__snapshots__/test.ts.snap
+++ b/array/__snapshots__/test.ts.snap
@@ -155,7 +155,7 @@ snapshot[`[u8; 100] [
 01
 `;
 
-snapshot[`uint8array Uint8Array(5) [ 1, 2, 3, 4, 5 ] 1`] = `
+snapshot[`uint8Array Uint8Array(5) [ 1, 2, 3, 4, 5 ] 1`] = `
 14
 01
 02
@@ -164,7 +164,7 @@ snapshot[`uint8array Uint8Array(5) [ 1, 2, 3, 4, 5 ] 1`] = `
 05
 `;
 
-snapshot[`uint8array Uint8Array(5) [ 6, 7, 8, 9, 10 ] 1`] = `
+snapshot[`uint8Array Uint8Array(5) [ 6, 7, 8, 9, 10 ] 1`] = `
 14
 06
 07
@@ -173,7 +173,7 @@ snapshot[`uint8array Uint8Array(5) [ 6, 7, 8, 9, 10 ] 1`] = `
 0a
 `;
 
-snapshot[`uint8array Uint8Array(5) [ 11, 12, 13, 14, 15 ] 1`] = `
+snapshot[`uint8Array Uint8Array(5) [ 11, 12, 13, 14, 15 ] 1`] = `
 14
 0b
 0c
@@ -182,7 +182,7 @@ snapshot[`uint8array Uint8Array(5) [ 11, 12, 13, 14, 15 ] 1`] = `
 0f
 `;
 
-snapshot[`uint8array Uint8Array(6) [ 16, 17, 18, 19, 20, 21 ] 1`] = `
+snapshot[`uint8Array Uint8Array(6) [ 16, 17, 18, 19, 20, 21 ] 1`] = `
 18
 10
 11
@@ -192,14 +192,14 @@ snapshot[`uint8array Uint8Array(6) [ 16, 17, 18, 19, 20, 21 ] 1`] = `
 15
 `;
 
-snapshot[`sizedUint8array Uint8Array(4) [ 0, 0, 0, 0 ] 1`] = `
+snapshot[`sizedUint8Array Uint8Array(4) [ 0, 0, 0, 0 ] 1`] = `
 00
 00
 00
 00
 `;
 
-snapshot[`sizedUint8array Uint8Array(4) [ 1, 2, 3, 4 ] 1`] = `
+snapshot[`sizedUint8Array Uint8Array(4) [ 1, 2, 3, 4 ] 1`] = `
 01
 02
 03

--- a/array/codec.ts
+++ b/array/codec.ts
@@ -55,8 +55,8 @@ export function array<T>($el: Codec<T>): Codec<T[]> {
   });
 }
 
-export const uint8array: Codec<Uint8Array> = createCodec({
-  name: "uint8array",
+export const uint8Array: Codec<Uint8Array> = createCodec({
+  name: "uint8Array",
   _metadata: null,
   _staticSize: compactU32._staticSize,
   _encode(buffer, value) {
@@ -71,10 +71,10 @@ export const uint8array: Codec<Uint8Array> = createCodec({
   },
 });
 
-export function sizedUint8array(length: number): Codec<Uint8Array> {
+export function sizedUint8Array(length: number): Codec<Uint8Array> {
   return createCodec({
-    name: "sizedUint8array",
-    _metadata: [sizedUint8array, length],
+    name: "sizedUint8Array",
+    _metadata: [sizedUint8Array, length],
     // We could set `_staticSize` to `length`, but in this case it will usually
     // more efficient to insert the array dynamically, rather than manually copy
     // the bytes.
@@ -88,3 +88,9 @@ export function sizedUint8array(length: number): Codec<Uint8Array> {
     },
   });
 }
+
+/** @deprecated Use `$.uint8Array` instead */
+export const uint8array = uint8Array;
+
+/** @deprecated Use `$.sizedUint8Array` instead */
+export const sizedUint8array = sizedUint8Array;

--- a/array/test.ts
+++ b/array/test.ts
@@ -12,14 +12,14 @@ testCodec("[u8; 1]", $.sizedArray($.u8, 1), [[1]]);
 testCodec("[u8; 2]", $.sizedArray($.u8, 2), [[1, 1]]);
 testCodec("[u8; 100]", $.sizedArray($.u8, 100), [Array(100).fill(1) as any]);
 
-testCodec("uint8array", $.uint8array, [
+testCodec("uint8Array", $.uint8Array, [
   new Uint8Array([1, 2, 3, 4, 5]),
   new Uint8Array([6, 7, 8, 9, 10]),
   new Uint8Array([11, 12, 13, 14, 15]),
   new Uint8Array([16, 17, 18, 19, 20, 21]),
 ]);
 
-testCodec("sizedUint8array", $.sizedUint8array(4), [
+testCodec("sizedUint8Array", $.sizedUint8Array(4), [
   new Uint8Array([0, 0, 0, 0]),
   new Uint8Array([1, 2, 3, 4]),
 ]);


### PR DESCRIPTION
This aligns the casing with the type, `Uint8Array`. The old casing is exported as an alias for backwards compat.